### PR TITLE
PHP 7.3

### DIFF
--- a/src/diagnostics.yaml
+++ b/src/diagnostics.yaml
@@ -110,6 +110,7 @@ diagnostics:
   text: "The modifier '%s' cannot be used on a class, interface, or trait"
 - name: ERR_BaseClassAfterImplements
   text: "Base class must come before any interfaces"
+# @todo Alternative: "A case label must be followed by a ':' or ';'"
 - name: ERR_CaseLabelSeparatorExpected
   text: "Expected ':' or ';' after case label"
 - name: ERR_CatchOrFinallyExpected
@@ -136,12 +137,16 @@ diagnostics:
   text: "A destructuring variable cannot be assigned by reference"
 - name: ERR_DuplicateModifier
   text: "Duplicate '%s' modifier"
+- name: ERR_EllipsisOrCloseParenExpected
+  text: "'...' or ')' expected"
 - name: ERR_ExpressionExpected
   text: "Expression expected, got '%s'"
 - name: ERR_ExpressionExpectedEOF
   text: "End of file found, expression expected"
 - name: ERR_ExpressionNotAddressable
   text: "The given expression does not have a usable address"
+- name: ERR_ExpressionOrCloseParenExpected
+  text: "Expression or ')' expected"
 - name: ERR_ExpressionOrColonExpected
   text: "Expression or ':' expected"
 - name: ERR_ExpressionOrSemicolonExpected

--- a/src/diagnostics.yaml
+++ b/src/diagnostics.yaml
@@ -48,6 +48,10 @@ diagnostics:
 - name: ERR_UnexpectedCharacter
   text: "Unexpected character (%s: '%s') in source text"
   code: 1000
+- name: ERR_HeredocIndentHasSpacesAndTabs
+  text: "Indentation contains both space and tab characters"
+- name: ERR_HeredocIndentMismatch
+  text: "Indentation does not match that of the closing identifier"
 - name: ERR_InvalidNumber
   text: "Invalid number"
 - name: ERR_InvalidEscapeSequenceUnicode

--- a/src/diagnostics.yaml
+++ b/src/diagnostics.yaml
@@ -195,6 +195,8 @@ diagnostics:
 # variable token, use `ERR_VariableNameExpected` instead.
 - name: ERR_IncompleteVariable
   text: "Expected a variable or indirect expression to evaluate as a variable name"
+- name: ERR_IndentExpected
+  text: "Indentation expected"
 - name: ERR_InterfaceImplementsList
   text: "The keyword 'implements' cannot be used on an interface"
 - name: ERR_InterfaceMethodDefinition

--- a/src/language/TokenKind.ts
+++ b/src/language/TokenKind.ts
@@ -195,6 +195,7 @@ export enum TokenKind {
   // Literals
   BackQuoteTemplate,        // Virtual.
   DNumber,
+  FlexdocTemplate,          // Virtual.
   HeredocEnd,
   HeredocStart,
   HeredocTemplate,          // Virtual.
@@ -202,7 +203,9 @@ export enum TokenKind {
   InlineText,               // T_INLINE_HTML
   LNumber,
   StringIdentifier,         // T_STRING_VARNAME
+  StringIndent,             // Custom.
   StringLiteral,            // T_CONSTANT_ENCAPSED_STRING (single quotes)
+  StringNewLine,            // Custom.
   StringNumber,             // T_NUM_STRING
   StringTemplate,           // Virtual.
   StringTemplateLiteral,    // T_ENCAPSED_AND_WHITESPACE (double quotes)

--- a/src/nodes.yaml
+++ b/src/nodes.yaml
@@ -306,6 +306,16 @@ nodes:
   - name: closeParen
     type: TokenNode
   visitorName: visitExpressionGroup
+- name: FlexibleHeredocTemplate
+  extends: Expression
+  properties:
+  - name: heredocStart
+    type: TokenNode
+  - name: flexibleElements
+    type: NodeList
+  - name: heredocEnd
+    type: TokenNode
+  visitorName: visitFlexibleHeredocTemplate
 # @todo Should not mix expression and name.
 - name: FunctionInvocation
   extends: Invocation
@@ -1628,6 +1638,14 @@ nodes:
     type: NodeList
     optional: true
   visitorName: visitElseIfBlock
+- name: FlexibleHeredocElement
+  properties:
+  - name: indent
+    type: TokenNode
+  - name: template
+    type: NodeList
+    optional: true
+  visitorName: visitFlexibleHeredocElement
 - name: FullyQualifiedName
   extends: Name
   properties:

--- a/src/parser/PhpLexer.ts
+++ b/src/parser/PhpLexer.ts
@@ -179,6 +179,11 @@ export class PhpLexer extends LexerBase<Token, PhpLexerState> {
   protected end: number = 0;
 
   /**
+   * The indentation to remove from lines in a flexdoc template.
+   */
+  protected flexibleIndent: string = '';
+
+  /**
    * Temporary storage for spans within a string template.
    */
   protected interpolations: TemplateSpan[] = [];
@@ -285,24 +290,50 @@ export class PhpLexer extends LexerBase<Token, PhpLexerState> {
 
   /**
    * Initializes the lexer with predetermined lexing regions found after
+   * scanning a `FlexdocTemplate` token.
+   */
+  public rescanInterpolatedFlexdoc(spans: TemplateSpan[]) {
+    if (spans.length < 1) {
+      throw new ArgumentException('Flexdoc template must contain at least one span');
+    }
+    if (spans[spans.length - 1].state != PhpLexerState.LookingForHeredocLabel) {
+      throw new ArgumentException('Flexdoc template must end with a label span');
+    }
+
+    this.defaultState = PhpLexerState.InFlexibleHeredoc;
+    this.state = PhpLexerState.LookingForHeredocLabel;
+    this.templateStack = spans;
+
+    let endSpan = spans[spans.length - 1];
+
+    // Get the indent.
+    let endLabel = this.text.substring(endSpan.start, endSpan.length);
+    for (let i = 0; i < endLabel.length; i++) {
+      if (!CharacterInfo.isWhitespace(endLabel.charCodeAt(i))) {
+        this.flexibleIndent = endLabel.substr(0, i);
+        break;
+      }
+    }
+
+    // Force the lexer to stop just before an end label instead of always
+    // trying to scan for it. After reaching the last span, this region will
+    // be "appended" and scanned normally.
+    this.end = this.end - endSpan.length;
+  }
+
+  /**
+   * Initializes the lexer with predetermined lexing regions found after
    * scanning a `HeredocTemplate` token.
    */
   public rescanInterpolatedHeredoc(spans: TemplateSpan[]) {
-    if (spans.length == 0) {
-      throw new ArgumentException('Heredoc template must contain at least one span');
-    }
-    if (spans[0].state != PhpLexerState.LookingForHeredocLabel) {
-      throw new ArgumentException('Heredoc template must start with a label span');
-    }
-
     this.defaultState = PhpLexerState.InHeredoc;
-    this.state = spans[0].state;
+    this.state = PhpLexerState.LookingForHeredocLabel;
     this.templateStack = spans;
 
     // Force the lexer to stop just before an end label instead of always
     // trying to scan for it. After reaching the last span, this region will
     // be "appended" and scanned normally.
-    if (spans.length > 1 && spans[spans.length - 1].state == PhpLexerState.LookingForHeredocLabel) {
+    if (spans.length > 0 && spans[spans.length - 1].state == PhpLexerState.LookingForHeredocLabel) {
       this.end = this.end - spans[spans.length - 1].length;
     }
   }
@@ -341,32 +372,37 @@ export class PhpLexer extends LexerBase<Token, PhpLexerState> {
 
       switch (this.state) {
         // Standard lexing states.
-        case PhpLexerState.InHostLanguage:  // 0
+        case PhpLexerState.InHostLanguage:
           this.state = this.lexInlineText();
           break;
-        case PhpLexerState.InScript:        // 5
+        case PhpLexerState.InScript:
           this.state = this.lexScript();
           break;
 
         // Rescanning states.
-        case PhpLexerState.InBackQuote:             // 1
-        case PhpLexerState.InDoubleQuote:           // 2
-        case PhpLexerState.InHeredoc:               // 3
-          this.state = this.lexString(this.state);
+        case PhpLexerState.InBackQuote:
+        case PhpLexerState.InDoubleQuote:
+        case PhpLexerState.InFlexibleHeredoc:
+        case PhpLexerState.InHeredoc:
+          this.state = this.lexString();
           break;
-        case PhpLexerState.InNowdoc:                // 4
+        case PhpLexerState.InFlexibleNowdoc:
+        case PhpLexerState.InNowdoc:
           this.state = this.lexNowdoc();
           break;
-        case PhpLexerState.InVariableOffset:        // 6
+        case PhpLexerState.InVariableOffset:
           this.state = this.lexVariableOffset();
           break;
-        case PhpLexerState.LookingForHeredocLabel:  // 7
+        case PhpLexerState.LookingForHeredocIndent:
+          this.state = this.lexString();
+          break;
+        case PhpLexerState.LookingForHeredocLabel:
           this.state = this.lexHeredocLabel();
           break;
         // case PhpLexerState.LookingForProperty:
         //   this.state = this.lexProperty();
         //   break;
-        case PhpLexerState.LookingForVariableName:  // 8
+        case PhpLexerState.LookingForVariableName:
           this.state = this.lexVariableName();
           break;
 
@@ -457,9 +493,43 @@ export class PhpLexer extends LexerBase<Token, PhpLexerState> {
     // Don't move the actual lexer position.
     let offset = this.offset;
 
+    // PHP 7.3 allows leading whitespace.
+    if (this.phpVersion >= PhpVersion.PHP7_3) {
+      while (offset < this.end && CharacterInfo.isWhitespace(this.text.charCodeAt(offset))) {
+        offset++;
+      }
+    }
+
     // End label.
-    if (!this.startsWith(label, false)) {
+    if (offset + label.length > this.end) {
       return false;
+    }
+
+    let labelStart = offset;
+    if (CharacterInfo.isIdentifierStart(this.text.charCodeAt(offset))) {
+      offset++;
+
+      // No partial matches, so get the full identifier.
+      while (offset < this.end) {
+        let ch = this.text.charCodeAt(offset);
+        if (!CharacterInfo.isIdentifierPart(ch, this.phpVersion)) {
+          break;
+        }
+        offset++;
+      }
+
+      // Compare to the label.
+      if (this.text.substring(labelStart, offset - labelStart) !== label) {
+        return false;
+      }
+    }
+    else {
+      return false;
+    }
+
+    // PHP 7.3 also removes requirements for trailing characters.
+    if (this.phpVersion >= PhpVersion.PHP7_3) {
+      return true;
     }
 
     offset = offset + label.length;
@@ -482,14 +552,22 @@ export class PhpLexer extends LexerBase<Token, PhpLexerState> {
    * Tokenizes a starting or ending heredoc label.
    */
   protected lexHeredocLabel(): PhpLexerState {
-    if (this.text.charCodeAt(this.offset) == Character.LessThan) {
+    let ch = this.text.charCodeAt(this.offset);
+    if (ch == Character.LessThan) {
       let info = this.tryScanHeredocStartLabel();
-
-      if (info && info.isNowdoc) {
-        this.defaultState = PhpLexerState.InNowdoc;
+      if (this.flexibleIndent) {
+        this.state = PhpLexerState.LookingForHeredocIndent;
+      }
+      else {
+        this.state = (info && info.isNowdoc) ? PhpLexerState.InNowdoc : PhpLexerState.InHeredoc;
       }
 
       this.tokenKind = TokenKind.HeredocStart;
+    }
+    else if (CharacterInfo.isWhitespace(ch)) {
+      // NOTE: Do not move past the first whitespace character yet.
+      this.scanHeredocEndLabelIndent();
+      this.tokenKind = TokenKind.StringIndent;
     }
     else {
       this.offset++;
@@ -532,10 +610,44 @@ export class PhpLexer extends LexerBase<Token, PhpLexerState> {
    * Tokenizes the text of a nowdoc string.
    */
   protected lexNowdoc(): PhpLexerState {
-    // The end label has been temporarily removed, so there's nothing to do
-    // but instantaneously parse the string...
-    this.offset = this.end;
-    this.tokenKind = TokenKind.StringTemplateLiteral;
+    // In a regular nowdoc, the end label has been temporarily removed, so
+    // there's nothing to do but instantaneously tokenize the string.
+    if (this.state == PhpLexerState.InNowdoc) {
+      this.offset = this.end;
+      this.tokenKind = TokenKind.StringTemplateLiteral;
+      return this.state;
+    }
+
+    // A flexible nowdoc actually has some tokens though.
+    let ch = this.text.charCodeAt(this.offset);
+
+    switch (ch) {
+      case Character.Space:
+      case Character.Tab:
+        if (this.state == PhpLexerState.LookingForHeredocIndent) {
+          this.tryScanFlexdocIndent();
+          this.tokenKind = TokenKind.StringIndent;
+          this.state = PhpLexerState.InFlexibleNowdoc;
+          break;
+        }
+        this.tryScanNowdocString();
+        this.tokenKind = TokenKind.StringTemplateLiteral;
+        break;
+      case Character.CarriageReturn:
+      case Character.LineFeed:
+        this.offset++;
+        while (CharacterInfo.isLineBreak(this.text.charCodeAt(this.offset))) {
+          this.offset++;
+        }
+        this.tokenKind = TokenKind.StringNewLine;
+        this.state = PhpLexerState.LookingForHeredocIndent;
+        break;
+      default:
+        this.tryScanNowdocString();
+        this.tokenKind = TokenKind.StringTemplateLiteral;
+        break;
+    }
+
     return this.state;
   }
 
@@ -1052,16 +1164,16 @@ export class PhpLexer extends LexerBase<Token, PhpLexerState> {
    * Tokenizes the regions within a string template that are not part of an
    * interpolation.
    */
-  protected lexString(state: PhpLexerState): PhpLexerState {
+  protected lexString(): PhpLexerState {
     let ch = this.text.charCodeAt(this.offset);
     let next = this.peek(this.offset + 1);
 
-    if (state == PhpLexerState.InDoubleQuote && ch == Character.DoubleQuote) {
+    if (this.state == PhpLexerState.InDoubleQuote && ch == Character.DoubleQuote) {
       this.offset++;
       this.tokenKind = TokenKind.DoubleQuote;
       return this.state;
     }
-    else if (state == PhpLexerState.InBackQuote && ch == Character.BackQuote) {
+    else if (this.state == PhpLexerState.InBackQuote && ch == Character.BackQuote) {
       this.offset++;
       this.tokenKind = TokenKind.BackQuote;
       return this.state;
@@ -1077,7 +1189,7 @@ export class PhpLexer extends LexerBase<Token, PhpLexerState> {
         }
         else {
           this.offset++;
-          this.tryScanStringTemplateLiteral(this.state);
+          this.tryScanStringTemplateLiteral();
           this.tokenKind = TokenKind.StringTemplateLiteral;
         }
         break;
@@ -1087,13 +1199,41 @@ export class PhpLexer extends LexerBase<Token, PhpLexerState> {
           this.tokenKind = TokenKind.OpenBrace;
         }
         else {
-          this.tryScanStringTemplateLiteral(this.state);
+          this.tryScanStringTemplateLiteral();
+          this.tokenKind = TokenKind.StringTemplateLiteral;
+        }
+        break;
+      case Character.Space:
+      case Character.Tab:
+        if (this.state == PhpLexerState.LookingForHeredocIndent) {
+          this.state = PhpLexerState.InFlexibleHeredoc;
+          let length = this.tryScanFlexdocIndent();
+          if (length > 0) {
+            this.tokenKind = TokenKind.StringIndent;
+            break;
+          }
+        }
+        this.tryScanStringTemplateLiteral();
+        this.tokenKind = TokenKind.StringTemplateLiteral;
+        break;
+      case Character.CarriageReturn:
+      case Character.LineFeed:
+        if (this.state == PhpLexerState.InFlexibleHeredoc || this.state == PhpLexerState.LookingForHeredocIndent) {
+          this.offset++;
+          while (CharacterInfo.isLineBreak(this.text.charCodeAt(this.offset))) {
+            this.offset++;
+          }
+          this.tokenKind = TokenKind.StringNewLine;
+          this.state = PhpLexerState.LookingForHeredocIndent;
+        }
+        else {
+          this.tryScanStringTemplateLiteral();
           this.tokenKind = TokenKind.StringTemplateLiteral;
         }
         break;
       default:
         // @todo Assert that this length is greater than 0.
-        this.tryScanStringTemplateLiteral(this.state);
+        this.tryScanStringTemplateLiteral();
         this.tokenKind = TokenKind.StringTemplateLiteral;
         break;
     }
@@ -1224,6 +1364,36 @@ export class PhpLexer extends LexerBase<Token, PhpLexerState> {
     }
 
     this.tokenKind = length < this.ptrSize * 8 ? TokenKind.LNumber : TokenKind.DNumber;
+    return this.offset - start;
+  }
+
+  /**
+   * Scans the indentation of the end label in a flexdoc template.
+   */
+  protected scanHeredocEndLabelIndent() {
+    const start = this.offset;
+
+    let hasSpaces = false;
+    let hasTabs = false;
+
+    while (this.offset < this.end) {
+      let ch = this.text.charCodeAt(this.offset);
+      if (ch == Character.Space) {
+        hasSpaces = true;
+      }
+      else if (ch == Character.Tab) {
+        hasTabs = true;
+      }
+      else {
+        break;
+      }
+      this.offset++;
+    }
+
+    if (hasSpaces && hasTabs) {
+      this.addError(0, this.offset - start, ErrorCode.ERR_HeredocIndentHasSpacesAndTabs);
+    }
+
     return this.offset - start;
   }
 
@@ -1390,6 +1560,7 @@ export class PhpLexer extends LexerBase<Token, PhpLexerState> {
             if (info) {
               this.scanInterpolatedString(info.label);
               if (this.isHeredocEnd(info.label)) {
+                this.scanWhitespace();
                 this.offset = this.offset + info.label.length;
               }
               break;
@@ -1439,7 +1610,7 @@ export class PhpLexer extends LexerBase<Token, PhpLexerState> {
   /**
    * Scans the contents of a possible interpolated string.
    *
-   * @param {Character|string} label
+   * @param {Character|string} delimiter
    *   A closing quote or label used to delimit a heredoc or nowdoc string.
    * @param {TemplateSpan[]=} spans
    *   An array to store any scanned interpolations within the string.
@@ -1907,6 +2078,50 @@ export class PhpLexer extends LexerBase<Token, PhpLexerState> {
   }
 
   /**
+   * Attempts to scan for the indent in a flexible heredoc. If not found,
+   * nothing is scanned.
+   */
+  protected tryScanFlexdocIndent(): number {
+    const start = this.offset;
+
+    let hasMismatchedIndentation = false;
+
+    for (let i = 0; i < this.flexibleIndent.length; i++) {
+      if (this.offset >= this.end) {
+        throw new Exception('Missing end label');  // Unreachable.
+      }
+
+      let ch = this.text.charCodeAt(this.offset);
+      if (ch != this.flexibleIndent.charCodeAt(i)) {
+        if (CharacterInfo.isLineBreak(ch)) {
+          // Found an empty line.
+          break;
+        }
+        else {
+          // Either this is a space instead of a tab, a tab instead of a space,
+          // or some other non-whitespace character. In the first two cases,
+          // continue scanning the indent in order to prevent "indent expected"
+          // errors when there is clearly whitespace present.
+          hasMismatchedIndentation = true;
+
+          // Found a line without enough indentation.
+          if (!CharacterInfo.isWhitespace(ch)) {
+            break;
+          }
+        }
+      }
+
+      this.offset++;
+    }
+
+    if (hasMismatchedIndentation && this.offset - start > 0) {
+      this.addError(0, this.offset - start, ErrorCode.ERR_HeredocIndentMismatch);
+    }
+
+    return this.offset - start;
+  }
+
+  /**
    * Attempts to scan for a heredoc or nowdoc string. If not found, a left
    * shift token is scanned instead.
    */
@@ -1916,14 +2131,18 @@ export class PhpLexer extends LexerBase<Token, PhpLexerState> {
     let info = this.tryScanHeredocStartLabel();
     if (info !== null) {
       spans.length = 0;  // Need to modify the existing array.
-      spans.push(new TemplateSpan(PhpLexerState.LookingForHeredocLabel, 0, info.fullLength));
 
       // The starting label consumes a trailing new line, so for an empty
-      // string, the search for an ending label is never triggered.
+      // string, the search for an ending label would never be triggered.
       if (this.isHeredocEnd(info.label)) {
-        spans.push(new TemplateSpan(PhpLexerState.LookingForHeredocLabel, this.offset - start, info.label.length));
+        this.tokenKind = CharacterInfo.isWhitespace(this.text.charCodeAt(this.offset))
+          ? TokenKind.FlexdocTemplate : TokenKind.HeredocTemplate;
+
+        let labelStart = this.offset - start;
+        let indentLength = this.scanWhitespace();
         this.offset = this.offset + info.label.length;
-        this.tokenKind = TokenKind.HeredocTemplate;
+
+        spans.push(new TemplateSpan(PhpLexerState.LookingForHeredocLabel, labelStart, indentLength + info.label.length));
         return this.offset - start;
       }
 
@@ -1935,13 +2154,19 @@ export class PhpLexer extends LexerBase<Token, PhpLexerState> {
       }
 
       if (this.isHeredocEnd(info.label)) {
-        spans.push(new TemplateSpan(PhpLexerState.LookingForHeredocLabel, this.offset - start, info.label.length));
+        this.tokenKind = CharacterInfo.isWhitespace(this.text.charCodeAt(this.offset))
+          ? TokenKind.FlexdocTemplate : TokenKind.HeredocTemplate;
+
+        let labelStart = this.offset - start;
+        let indentLength = this.scanWhitespace();
         this.offset = this.offset + info.label.length;
+
+        spans.push(new TemplateSpan(PhpLexerState.LookingForHeredocLabel, labelStart, indentLength + info.label.length));
       }
       else {
         this.addError(0, this.offset - start, info.isNowdoc ? ErrorCode.ERR_UnterminatedStringConstant : ErrorCode.ERR_UnterminatedString);
+        this.tokenKind = TokenKind.HeredocTemplate;
       }
-      this.tokenKind = TokenKind.HeredocTemplate;
     }
     else {
       // Starting label not found.
@@ -2029,6 +2254,22 @@ export class PhpLexer extends LexerBase<Token, PhpLexerState> {
   }
 
   /**
+   * Attempts to scan for constant text within a nowdoc.
+   */
+  protected tryScanNowdocString(): number {
+    const start = this.offset;
+
+    while (this.offset < this.end) {
+      if (CharacterInfo.isLineBreak(this.text.charCodeAt(this.offset))) {
+        break;
+      }
+      this.offset++;
+    }
+
+    return this.offset - start;
+  }
+
+  /**
    * Attempts to scan for an octal escape sequence.
    */
   protected tryScanOctalEscape(): number {
@@ -2082,7 +2323,7 @@ export class PhpLexer extends LexerBase<Token, PhpLexerState> {
   /**
    * Attempts to scan for constant text within a string template.
    */
-  protected tryScanStringTemplateLiteral(state: PhpLexerState): number {
+  protected tryScanStringTemplateLiteral(): number {
     const start = this.offset;
 
     while (this.offset < this.end) {
@@ -2090,10 +2331,10 @@ export class PhpLexer extends LexerBase<Token, PhpLexerState> {
       let next = this.peek(this.offset + 1);
 
       // String terminators.
-      if (state == PhpLexerState.InDoubleQuote && ch == Character.DoubleQuote) {
+      if (this.state == PhpLexerState.InDoubleQuote && ch == Character.DoubleQuote) {
         break;
       }
-      else if (state == PhpLexerState.InBackQuote && ch == Character.BackQuote) {
+      else if (this.state == PhpLexerState.InBackQuote && ch == Character.BackQuote) {
         break;
       }
 
@@ -2102,6 +2343,9 @@ export class PhpLexer extends LexerBase<Token, PhpLexerState> {
         break;
       }
       else if (ch == Character.OpenBrace && next == Character.Dollar) {
+        break;
+      }
+      else if ((this.state == PhpLexerState.InFlexibleHeredoc || this.state == PhpLexerState.LookingForHeredocIndent) && CharacterInfo.isLineBreak(ch)) {
         break;
       }
       else if (ch == Character.Backslash) {

--- a/src/parser/PhpLexer.ts
+++ b/src/parser/PhpLexer.ts
@@ -1348,19 +1348,25 @@ export class PhpLexer extends LexerBase<Token, PhpLexerState> {
         case Character.OpenBrace:
           this.offset++;  // "{"
           this.scanInterpolatedScript(Character.CloseBrace);
-          this.offset++;  // "}"
+          if (this.peek(this.offset) == Character.CloseBrace) {
+            this.offset++;
+          }
           break;
         case Character.OpenBracket:
           // @todo This may be unnecessary?
           this.offset++;  // "["
           this.scanInterpolatedScript(Character.CloseBracket);
-          this.offset++;  // "]"
+          if (this.peek(this.offset) == Character.CloseBracket) {
+            this.offset++;
+          }
           break;
         case Character.OpenParen:
           // @todo This may be unnecessary?
           this.offset++;  // "("
           this.scanInterpolatedScript(Character.CloseParen);
-          this.offset++;  // ")"
+          if (this.peek(this.offset) == Character.CloseParen) {
+            this.offset++;
+          }
           break;
 
         // Strings.
@@ -1524,7 +1530,9 @@ export class PhpLexer extends LexerBase<Token, PhpLexerState> {
             }
 
             this.scanInterpolatedScript(Character.CloseBrace);
-            this.offset++;  // "}"
+            if (this.peek(this.offset) == Character.CloseBrace) {
+              this.offset++;
+            }
 
             spans.push(new TemplateSpan(PhpLexerState.InScript, spanOffset - tokenOffset, this.offset - spanOffset));
           }
@@ -1570,7 +1578,9 @@ export class PhpLexer extends LexerBase<Token, PhpLexerState> {
           if (next == Character.Dollar) {
             spanOffset = this.offset;
             this.scanInterpolatedScript(Character.CloseBrace);
-            this.offset++;  // "}"
+            if (this.peek(this.offset) == Character.CloseBrace) {
+              this.offset++;
+            }
             spans.push(new TemplateSpan(PhpLexerState.InScript, spanOffset - tokenOffset, this.offset - spanOffset));
           }
           break;

--- a/src/parser/PhpLexerState.ts
+++ b/src/parser/PhpLexerState.ts
@@ -37,6 +37,15 @@ export const enum PhpLexerState {
    */
   InDoubleQuote,
   /**
+   * The default lexing state when rescanning a `FlexdocTemplate`.
+   */
+  InFlexibleHeredoc,
+  /**
+   * The default lexing state when rescanning a `FlexdocTemplate` that starts
+   * with a nowdoc label.
+   */
+  InFlexibleNowdoc,
+  /**
    * The default lexing state when rescanning a `HeredocTemplate`.
    */
   InHeredoc,
@@ -56,6 +65,10 @@ export const enum PhpLexerState {
    * string interpolation.
    */
   InVariableOffset,
+  /**
+   * A lexing state used when rescanning the whitespace after a line break.
+   */
+  LookingForHeredocIndent,
   /**
    * A lexing state used when rescanning heredoc start or end labels.
    */

--- a/src/parser/PhpParser.ts
+++ b/src/parser/PhpParser.ts
@@ -3755,12 +3755,17 @@ export class PhpParser implements IParser<SourceTextSyntaxNode> {
 
     while (this.currentToken.kind == TokenKind.Comma) {
       expressions.push(this.eat(TokenKind.Comma));
+      if (!this.isExpressionStart(this.currentToken.kind)) {
+        break;  // @todo Requires PHP 7.3 or later.
+      }
       expressions.push(this.parseExpression(ExpressionType.Explicit));
     }
 
     let closeParen = this.currentToken.kind == TokenKind.CloseParen
       ? this.eat(TokenKind.CloseParen)
-      : this.createMissingTokenWithError(TokenKind.CloseParen, ErrorCode.ERR_CommaOrCloseParenExpected);
+      : expressions.length & 1
+        ? this.createMissingTokenWithError(TokenKind.CloseParen, ErrorCode.ERR_CommaOrCloseParenExpected)
+        : this.createMissingTokenWithError(TokenKind.CloseParen, ErrorCode.ERR_ExpressionOrCloseParenExpected);
     let semicolon = this.parseStatementEnd();
     return new UnsetNode(
       unsetKeyword,

--- a/src/parser/PhpParser.ts
+++ b/src/parser/PhpParser.ts
@@ -2369,11 +2369,9 @@ export class PhpParser implements IParser<SourceTextSyntaxNode> {
     // In the above scenario, the parser does not know if the opening bracket
     // should start a deconstruction or an array initializer and as a result,
     // needs to parse it as either. Sadly, this means that invalid
-    // deconstructions AND array initializers are not syntax errors.
+    // array initializers are not syntax errors.
     //
     //   [,$a]   // Valid deconstruction, invalid array.
-    //
-    //   [&$a]   // Valid array, invalid deconstruction.
     //
     let expr = this.parseExpressionTree();
     let value = <ExpressionNode>expr.node;

--- a/src/parser/PhpParser.ts
+++ b/src/parser/PhpParser.ts
@@ -5078,12 +5078,17 @@ export class PhpParser implements IParser<SourceTextSyntaxNode> {
 
     while (this.currentToken.kind == TokenKind.Comma) {
       expressions.push(this.eat(TokenKind.Comma));
+      if (!this.isExpressionStart(this.currentToken.kind)) {
+        break;  // @todo Requires PHP 7.3 or later.
+      }
       expressions.push(this.parseExpression());
     }
 
     let closeParen = this.currentToken.kind == TokenKind.CloseParen
       ? this.eat(TokenKind.CloseParen)
-      : this.createMissingTokenWithError(TokenKind.CloseParen, ErrorCode.ERR_CommaOrCloseParenExpected);
+      : expressions.length & 1
+        ? this.createMissingTokenWithError(TokenKind.CloseParen, ErrorCode.ERR_CommaOrCloseParenExpected)
+        : this.createMissingTokenWithError(TokenKind.CloseParen, ErrorCode.ERR_ExpressionOrCloseParenExpected);
     return new IsSetIntrinsicNode(isSetKeyword, openParen, this.factory.createList(expressions), closeParen);
   }
 

--- a/src/parser/PhpParser.ts
+++ b/src/parser/PhpParser.ts
@@ -4617,6 +4617,7 @@ export class PhpParser implements IParser<SourceTextSyntaxNode> {
       array = this.parseArray();
     }
     else {
+      // Short syntax.
       array = this.parseArray();
       if (this.currentToken.kind == TokenKind.Equal) {
         let operator = this.eat(TokenKind.Equal);
@@ -5193,11 +5194,9 @@ export class PhpParser implements IParser<SourceTextSyntaxNode> {
       return new ListDestructureElementNode(null, null, null, list);
     }
 
-    // When using the []-syntax form, a user may try to make an assignment
-    // by reference, which would be valid if this were an array initializer.
     let ampersand = this.eatOptional(TokenKind.Ampersand);
     if (ampersand) {
-      ampersand = this.addError(ampersand, ErrorCode.ERR_DeconstructVariableReference);
+      // @todo Requires PHP 7.3 or later.
       let byRefValue = this.parseExpression(ExpressionType.Explicit);
       return new ListDestructureElementNode(null, null, ampersand, byRefValue);
     }
@@ -5221,10 +5220,9 @@ export class PhpParser implements IParser<SourceTextSyntaxNode> {
     let key = <ExpressionNode>expr.node;
     let doubleArrow = this.eat(TokenKind.DoubleArrow);
 
-    // See above.
     ampersand = this.eatOptional(TokenKind.Ampersand);
     if (ampersand) {
-      ampersand = this.addError(ampersand, ErrorCode.ERR_DeconstructVariableReference);
+      // @todo Requires PHP 7.3 or later.
     }
 
     // Suppress TS2365: Current token changed after previous method call.

--- a/src/parser/PhpParser.ts
+++ b/src/parser/PhpParser.ts
@@ -3734,8 +3734,8 @@ export class PhpParser implements IParser<SourceTextSyntaxNode> {
    * Syntax: `UNSET ( unset-list ) ;`
    *
    * Where `unset-list` is:
-   * - `unset-list , VARIABLE`
-   * - `VARIABLE`
+   * - `unset-list , expr`
+   * - `expr`
    */
   protected parseUnset(): UnsetNode {
     let unsetKeyword = this.eat(TokenKind.Unset);
@@ -4570,6 +4570,7 @@ export class PhpParser implements IParser<SourceTextSyntaxNode> {
 
     // An array is implicit if there is no dereference.
     let type = ExpressionType.Implicit;
+
     // NOTE: While PHP does allow an object operator after an array, it always
     // leads to an error. Additionally, while arrays cannot normally be used
     // with an argument list there is one exception:

--- a/src/parser/PhpParser.ts
+++ b/src/parser/PhpParser.ts
@@ -3049,7 +3049,9 @@ export class PhpParser implements IParser<SourceTextSyntaxNode> {
   protected parseReturn(): ReturnNode {
     let returnKeyword = this.eat(TokenKind.Return);
     let expression = this.isExpressionStart(this.currentToken.kind) ? this.parseExpression() : null;
-    let semicolon = this.parseStatementEnd();
+    let semicolon = expression === null && !this.isStatementEnd(this.currentToken.kind)
+      ? this.createMissingTokenWithError(TokenKind.Semicolon, ErrorCode.ERR_ExpressionOrSemicolonExpected)
+      : this.parseStatementEnd();
     return new ReturnNode(returnKeyword, expression, semicolon);
   }
 

--- a/src/parser/PhpVersion.ts
+++ b/src/parser/PhpVersion.ts
@@ -25,7 +25,8 @@ export enum PhpVersion {
   PHP7_0,
   PHP7_1,
   PHP7_2,
-  Latest = PHP7_2
+  PHP7_3,
+  Latest = PHP7_3
 
 }
 
@@ -45,6 +46,8 @@ export class PhpVersionInfo {
         return '7.1';
       case PhpVersion.PHP7_2:
         return '7.2';
+      case PhpVersion.PHP7_3:
+        return '7.3';
       default:
         return '';
     }

--- a/test/src/parser/PhpLexerTest_Interpolations.ts
+++ b/test/src/parser/PhpLexerTest_Interpolations.ts
@@ -242,7 +242,7 @@ describe('PhpLexer', function() {
 
         // Invalid offsets.
         new LexerTestArgs('"$a[0.1]"', 'variable with floating-point offset',
-        [TokenKind.DoubleQuote, TokenKind.Variable, TokenKind.OpenBracket, TokenKind.StringNumber, TokenKind.StringTemplateLiteral, TokenKind.DoubleQuote]
+          [TokenKind.DoubleQuote, TokenKind.Variable, TokenKind.OpenBracket, TokenKind.StringNumber, TokenKind.StringTemplateLiteral, TokenKind.DoubleQuote]
         ),
         new LexerTestArgs('"$a[-B]"', 'negative constant',
           [TokenKind.DoubleQuote, TokenKind.Variable, TokenKind.OpenBracket, TokenKind.Minus, TokenKind.StringTemplateLiteral, TokenKind.DoubleQuote]
@@ -275,19 +275,42 @@ describe('PhpLexer', function() {
     let lexerTests = [
       new LexerTestArgs('<<<LABEL\nLABEL\n', 'empty text',
         [TokenKind.HeredocStart, TokenKind.HeredocEnd],
-        ['<<<LABEL\n', 'LABEL']),
+        ['<<<LABEL\n', 'LABEL']
+      ),
       new LexerTestArgs('<<<LABEL\ntext\nLABEL\n', 'plain text',
         [TokenKind.HeredocStart, TokenKind.StringTemplateLiteral, TokenKind.HeredocEnd],
-        ['<<<LABEL\n', 'text\n', 'LABEL']),
+        ['<<<LABEL\n', 'text\n', 'LABEL']
+      ),
       new LexerTestArgs('<<<LABEL\n$a\nLABEL\n', 'simple variable',
         [TokenKind.HeredocStart, TokenKind.Variable, TokenKind.StringTemplateLiteral, TokenKind.HeredocEnd],
-        ['<<<LABEL\n', '$a', '\n', 'LABEL']),
-      new LexerTestArgs('<<<LABEL\nlabel\n', 'heredoc label should be case-sensitive',
-        [TokenKind.HeredocStart, TokenKind.StringTemplateLiteral],
-        ['<<<LABEL\n', 'label\n']),
-      new LexerTestArgs('<<<LABEL\n\n\nLABEL\n', 'multiple newlines before end label',
+        ['<<<LABEL\n', '$a', '\n', 'LABEL']
+      ),
+
+      new LexerTestArgs('<<< LABEL\nLABEL\n', 'heredoc start label should allow leading space',
+        [TokenKind.HeredocStart, TokenKind.HeredocEnd],
+        ['<<< LABEL\n', 'LABEL']
+      ),
+      new LexerTestArgs('<<<\tLABEL\nLABEL\n', 'heredoc start label should allow leading tab',
+        [TokenKind.HeredocStart, TokenKind.HeredocEnd],
+        ['<<<\tLABEL\n', 'LABEL']
+      ),
+
+      new LexerTestArgs('<<<LABEL\n LABEL\nLABEL\n', 'heredoc end label should be at start of line',
         [TokenKind.HeredocStart, TokenKind.StringTemplateLiteral, TokenKind.HeredocEnd],
-        ['<<<LABEL\n', '\n\n', 'LABEL']),
+        ['<<<LABEL\n', ' LABEL\n', 'LABEL']
+      ),
+      new LexerTestArgs('<<<LABEL\n\n\nLABEL\n', 'heredoc end label should be at start of line (multiple lines)',
+        [TokenKind.HeredocStart, TokenKind.StringTemplateLiteral, TokenKind.HeredocEnd],
+        ['<<<LABEL\n', '\n\n', 'LABEL']
+      ),
+      new LexerTestArgs('<<<LABEL\nLABEL', 'heredoc end label should have trailing line break',
+        [TokenKind.HeredocStart, TokenKind.StringTemplateLiteral],
+        ['<<<LABEL\n', 'LABEL']
+      ),
+      new LexerTestArgs('<<<LABEL\nlabel\n', 'heredoc end label should be case-sensitive',
+        [TokenKind.HeredocStart, TokenKind.StringTemplateLiteral],
+        ['<<<LABEL\n', 'label\n']
+      ),
     ];
     assertRescannedTokens(lexerTests, TokenKind.HeredocTemplate);
   });
@@ -296,28 +319,39 @@ describe('PhpLexer', function() {
     let lexerTests = [
       new LexerTestArgs('<<<"LABEL"\nLABEL\n', 'empty text',
         [TokenKind.HeredocStart, TokenKind.HeredocEnd],
-        ['<<<"LABEL"\n', 'LABEL']),
+        ['<<<"LABEL"\n', 'LABEL']
+      ),
       new LexerTestArgs('<<<"LABEL"\ntext\nLABEL\n', 'plain text',
         [TokenKind.HeredocStart, TokenKind.StringTemplateLiteral, TokenKind.HeredocEnd],
-        ['<<<"LABEL"\n', 'text\n', 'LABEL']),
+        ['<<<"LABEL"\n', 'text\n', 'LABEL']
+      ),
       new LexerTestArgs('<<<"LABEL"\n$a\nLABEL\n', 'simple variable',
         [TokenKind.HeredocStart, TokenKind.Variable, TokenKind.StringTemplateLiteral, TokenKind.HeredocEnd],
-        ['<<<"LABEL"\n', '$a', '\n', 'LABEL']),
+        ['<<<"LABEL"\n', '$a', '\n', 'LABEL']
+      ),
       new LexerTestArgs('<<<"LABEL"\nlabel\n', 'heredoc label should be case-sensitive',
         [TokenKind.HeredocStart, TokenKind.StringTemplateLiteral],
-        ['<<<"LABEL"\n', 'label\n']),
+        ['<<<"LABEL"\n', 'label\n']
+      ),
     ];
     assertRescannedTokens(lexerTests, TokenKind.HeredocTemplate);
   });
 
   describe('nowdoc strings', function() {
     let lexerTests = [
-      new LexerTestArgs('<<<\'LABEL\'\nLABEL\n', 'empty text', [TokenKind.HeredocStart, TokenKind.HeredocEnd]),
-      new LexerTestArgs('<<<\'LABEL\'\ntext\nLABEL\n', 'plain text', [TokenKind.HeredocStart, TokenKind.StringTemplateLiteral, TokenKind.HeredocEnd]),
-      new LexerTestArgs('<<<\'LABEL\'\n$a\nLABEL\n', 'simple variable', [TokenKind.HeredocStart, TokenKind.StringTemplateLiteral, TokenKind.HeredocEnd]),
+      new LexerTestArgs('<<<\'LABEL\'\nLABEL\n', 'empty text',
+        [TokenKind.HeredocStart, TokenKind.HeredocEnd]
+      ),
+      new LexerTestArgs('<<<\'LABEL\'\ntext\nLABEL\n', 'plain text',
+        [TokenKind.HeredocStart, TokenKind.StringTemplateLiteral, TokenKind.HeredocEnd]
+      ),
+      new LexerTestArgs('<<<\'LABEL\'\n$a\nLABEL\n', 'simple variable',
+        [TokenKind.HeredocStart, TokenKind.StringTemplateLiteral, TokenKind.HeredocEnd]
+      ),
       new LexerTestArgs('<<<\'LABEL\'\n\n\nLABEL\n', 'multiple newlines before end label',
         [TokenKind.HeredocStart, TokenKind.StringTemplateLiteral, TokenKind.HeredocEnd],
-        ['<<<\'LABEL\'\n', '\n\n', 'LABEL']),
+        ['<<<\'LABEL\'\n', '\n\n', 'LABEL']
+      ),
     ];
     assertRescannedTokens(lexerTests, TokenKind.HeredocTemplate);
   });

--- a/test/src/parser/PhpParserTest_Expressions.ts
+++ b/test/src/parser/PhpParserTest_Expressions.ts
@@ -791,7 +791,7 @@ describe('PhpParser', function() {
         assert.equal(elements.length, 1);
         assertArrayElement(elements[0], true, false);
       }),
-      new ParserTestArgs('array(1 => &$a);', 'should parse an array creation expression with key-value pair (byref)', (statements) => {
+      new ParserTestArgs('array(1 => &$a);', 'should parse an array creation expression with key-value pair (byref value)', (statements) => {
         let exprNode = <ExpressionStatementSyntaxNode>statements[0];
         assert.equal(exprNode instanceof ExpressionStatementSyntaxNode, true, 'ExpressionStatementSyntaxNode');
         let arrayNode = <ArraySyntaxNode>exprNode.expression;
@@ -819,10 +819,12 @@ describe('PhpParser', function() {
       new DiagnosticTestArgs('array(', 'missing expression or close paren', [ErrorCode.ERR_CloseParenExpected], [6]),
       // @todo Improve error message.
       new DiagnosticTestArgs('array(1', 'missing comma, close paren, or double arrow', [ErrorCode.ERR_CloseParenExpected], [7]),
-
-      // @todo Disabled. Allowed for list destructuring (uses same code as []-syntax).
-      // new DiagnosticTestArgs('array(,);', 'should not parse an array with missing element', [ErrorCode.ERR_ExpressionExpected], [6]),
       new DiagnosticTestArgs('array(&1);', 'should expect explicit byref value', [ErrorCode.ERR_ExpressionNotAddressable], [7]),
+
+      // @todo Recovery tests.
+      new DiagnosticTestArgs('array(&$a => $b);', 'should not parse an array with byref key', [ErrorCode.ERR_Syntax, ErrorCode.ERR_UnexpectedToken], [12, 10]),
+      // @todo Disabled. Allowed for list destructuring (uses same code as []-syntax).
+      // new DiagnosticTestArgs('array(,$a);', 'should not parse an array with missing element', [ErrorCode.ERR_ExpressionExpected], [6]),
     ];
     Test.assertDiagnostics(diagnosticTests);
   });
@@ -907,6 +909,13 @@ describe('PhpParser', function() {
       }),
     ];
     Test.assertSyntaxNodes(syntaxTests);
+
+    // NOTE: See array-creation-expression for array element tests.
+    let diagnosticTests = [
+      // @todo Improve error message.
+      new DiagnosticTestArgs('[', 'missing expression or close bracket', [ErrorCode.ERR_Syntax], [1]),
+    ];
+    Test.assertDiagnostics(diagnosticTests);
   });
 
   describe('unary-expression', function() {

--- a/test/src/parser/PhpParserTest_Expressions.ts
+++ b/test/src/parser/PhpParserTest_Expressions.ts
@@ -401,14 +401,35 @@ describe('PhpParser', function() {
           assert.equal(expressions[0] instanceof LocalVariableSyntaxNode, true);
           assert.equal(expressions[1] instanceof LocalVariableSyntaxNode, true);
         }),
+        new ParserTestArgs('isset($a,);', 'should parse an isset expression with trailing comma', (statements, text) => {
+          let exprNode = <ExpressionStatementSyntaxNode>statements[0];
+          assert.equal(exprNode instanceof ExpressionStatementSyntaxNode, true, 'ExpressionStatementSyntaxNode');
+          let isSetNode = <IsSetIntrinsicSyntaxNode>exprNode.expression;
+          assert.equal(isSetNode instanceof IsSetIntrinsicSyntaxNode, true);
+          let expressions = isSetNode.expressions.childNodes();
+          assert.equal(expressions.length, 1);
+          assert.equal(expressions[0] instanceof LocalVariableSyntaxNode, true);
+        }),
+        new ParserTestArgs('isset($a, $b,);', 'should parse an isset expression with trailing comma after expression list', (statements, text) => {
+          let exprNode = <ExpressionStatementSyntaxNode>statements[0];
+          assert.equal(exprNode instanceof ExpressionStatementSyntaxNode, true, 'ExpressionStatementSyntaxNode');
+          let isSetNode = <IsSetIntrinsicSyntaxNode>exprNode.expression;
+          assert.equal(isSetNode instanceof IsSetIntrinsicSyntaxNode, true);
+          let expressions = isSetNode.expressions.childNodes();
+          assert.equal(expressions.length, 2);
+          assert.equal(expressions[0] instanceof LocalVariableSyntaxNode, true);
+          assert.equal(expressions[1] instanceof LocalVariableSyntaxNode, true);
+        }),
       ];
       Test.assertSyntaxNodes(syntaxTests);
 
       let diagnosticTests = [
         new DiagnosticTestArgs('isset', 'missing open paren', [ErrorCode.ERR_OpenParenExpected], [5]),
         new DiagnosticTestArgs('isset(', 'missing expression', [ErrorCode.ERR_ExpressionExpectedEOF], [6]),
-        new DiagnosticTestArgs('isset($a', 'missing close paren or comma', [ErrorCode.ERR_CommaOrCloseParenExpected], [8]),
-        new DiagnosticTestArgs('isset($a, $b', 'missing close paren or comma (in list)', [ErrorCode.ERR_CommaOrCloseParenExpected], [12]),
+        new DiagnosticTestArgs('isset($a', 'missing comma or close paren', [ErrorCode.ERR_CommaOrCloseParenExpected], [8]),
+        new DiagnosticTestArgs('isset($a,', 'missing expression or close paren', [ErrorCode.ERR_ExpressionOrCloseParenExpected], [9]),
+        new DiagnosticTestArgs('isset($a, $b', 'missing comma or close paren (in list)', [ErrorCode.ERR_CommaOrCloseParenExpected], [12]),
+        new DiagnosticTestArgs('isset($a, $b,', 'missing expression or close paren (in list)', [ErrorCode.ERR_ExpressionOrCloseParenExpected], [13]),
       ];
       Test.assertDiagnostics(diagnosticTests);
     });

--- a/test/src/parser/PhpParserTest_Expressions.ts
+++ b/test/src/parser/PhpParserTest_Expressions.ts
@@ -705,7 +705,7 @@ describe('PhpParser', function() {
       new DiagnosticTestArgs('new class {', 'missing close brace or class member', [ErrorCode.ERR_CloseBraceExpected], [11]),
       new DiagnosticTestArgs('new class extends', 'missing name', [ErrorCode.ERR_TypeExpected], [17]),
       new DiagnosticTestArgs('new class implements', 'missing name', [ErrorCode.ERR_TypeExpected], [20]),
-      new DiagnosticTestArgs('new class (', 'missing argument', [ErrorCode.ERR_CloseParenExpected], [11]),
+      new DiagnosticTestArgs('new class (', 'missing argument or close paren', [ErrorCode.ERR_ExpressionOrCloseParenExpected], [11]),
       new DiagnosticTestArgs('new class ()', 'missing extends, implements, or open brace', [ErrorCode.ERR_IncompleteClassDeclaration], [12]),
     ];
     Test.assertDiagnostics(diagnosticTests);

--- a/test/src/parser/PhpParserTest_Expressions_Binary.ts
+++ b/test/src/parser/PhpParserTest_Expressions_Binary.ts
@@ -685,6 +685,12 @@ describe('PhpParser', function() {
           assert.equal(elements[0] instanceof ArrayElementSyntaxNode, true);
           assert.equal(elements[1] instanceof ArrayElementSyntaxNode, true);
         }),
+        new ParserTestArgs('[,$a] = $c;', 'should parse a destructuring assignment with leading comma', (statements) => {
+          let array = assertArrayDeconstruction(statements);
+          let elements = array.initializerList ? array.initializerList.childNodes() : [];
+          assert.equal(elements.length, 1);
+          assert.equal(elements[0] instanceof ArrayElementSyntaxNode, true);
+        }),
         new ParserTestArgs('[$a,] = $c;', 'should parse a destructuring assignment with trailing comma', (statements) => {
           let array = assertArrayDeconstruction(statements);
           let elements = array.initializerList ? array.initializerList.childNodes() : [];

--- a/test/src/parser/PhpParserTest_Expressions_Strings.ts
+++ b/test/src/parser/PhpParserTest_Expressions_Strings.ts
@@ -28,6 +28,8 @@ import {
 import {
   ElementAccessSyntaxNode,
   ExpressionStatementSyntaxNode,
+  FlexibleHeredocElementSyntaxNode,
+  FlexibleHeredocTemplateSyntaxNode,
   HeredocTemplateSyntaxNode,
   IndirectStringVariableSyntaxNode,
   LiteralSyntaxNode,
@@ -47,10 +49,40 @@ import { TokenKind } from '../../../src/language/TokenKind';
 function assertStringTemplate(statements: ISyntaxNode[]): ISyntaxNode[] {
   let exprNode = <ExpressionStatementSyntaxNode>statements[0];
   assert.equal(exprNode instanceof ExpressionStatementSyntaxNode, true, 'ExpressionStatementSyntaxNode');
-  let shellCommand = <StringTemplateSyntaxNode>exprNode.expression;
-  assert.equal(shellCommand instanceof StringTemplateSyntaxNode, true, 'StringTemplateSyntaxNode');
-  let contents = shellCommand.template ? shellCommand.template.childNodes() : [];
-  return contents;
+  let interpolatedString = <StringTemplateSyntaxNode>exprNode.expression;
+  assert.equal(interpolatedString instanceof StringTemplateSyntaxNode, true, 'StringTemplateSyntaxNode');
+  return interpolatedString.template.childNodes();
+}
+
+function assertFlexibleHeredocLine(node: ISyntaxNode, sourceText: string, indent: string, templateText?: string | null): ISyntaxNode[] {
+  let element = <FlexibleHeredocElementSyntaxNode>node;
+  assert.equal(element instanceof FlexibleHeredocElementSyntaxNode, true, 'FlexibleHeredocElementSyntaxNode');
+  Test.assertSyntaxToken(element.indent, sourceText, TokenKind.StringIndent, indent);
+  let template = element.template ? element.template.childNodes() : [];
+  if (templateText) {
+    // Simple literal.
+    assert.equal(template.length, 1);
+    let stringLiteral = <LiteralSyntaxNode>template[0];
+    assert.equal(stringLiteral instanceof LiteralSyntaxNode, true);
+    Test.assertSyntaxToken(stringLiteral.value, sourceText, TokenKind.StringTemplateLiteral, templateText);
+  }
+  else if (templateText === null) {
+    // Intended to be empty.
+    assert.strictEqual(element.template, null);
+  }
+  else {
+    // Interpolations.
+    assert.notEqual(template.length, 0);
+  }
+  return template;
+}
+
+function assertFlexibleHeredocTemplate(statements: ISyntaxNode[]): ISyntaxNode[] {
+  let exprNode = <ExpressionStatementSyntaxNode>statements[0];
+  assert.equal(exprNode instanceof ExpressionStatementSyntaxNode, true, 'ExpressionStatementSyntaxNode');
+  let interpolatedString = <FlexibleHeredocTemplateSyntaxNode>exprNode.expression;
+  assert.equal(interpolatedString instanceof FlexibleHeredocTemplateSyntaxNode, true, 'FlexibleHeredocTemplateSyntaxNode');
+  return interpolatedString.flexibleElements.childNodes();
 }
 
 describe('PhpParser', function() {
@@ -256,6 +288,136 @@ describe('PhpParser', function() {
     Test.assertSyntaxNodes(syntaxTests);
 
     // See heredoc for diagnostic tests.
+  });
+
+  describe('flexible-heredoc', function() {
+    let syntaxTests = [
+      new ParserTestArgs('<<<LABEL\n  LABEL;', 'should parse a flexible heredoc string (empty)', (statements, text) => {
+        let elements = assertFlexibleHeredocTemplate(statements);
+        assert.equal(elements.length, 1);
+        assertFlexibleHeredocLine(elements[0], text, '  ', null);
+      }),
+
+      new ParserTestArgs('<<<LABEL\n\n  LABEL;', 'should parse an empty line', (statements, text) => {
+        let elements = assertFlexibleHeredocTemplate(statements);
+        assert.equal(elements.length, 2);
+        let lineBreak = <LiteralSyntaxNode>elements[0];
+        assert.equal(lineBreak instanceof LiteralSyntaxNode, true, 'LiteralSyntaxNode');
+        Test.assertSyntaxToken(lineBreak.value, text, TokenKind.StringNewLine, '\n');
+        assertFlexibleHeredocLine(elements[1], text, '  ', null);
+      }),
+      new ParserTestArgs('<<<LABEL\n  \n  LABEL;', 'should parse an indented line', (statements, text) => {
+        let elements = assertFlexibleHeredocTemplate(statements);
+        assert.equal(elements.length, 3);
+        assertFlexibleHeredocLine(elements[0], text, '  ', null);
+        let lineBreak = <LiteralSyntaxNode>elements[1];
+        assert.equal(lineBreak instanceof LiteralSyntaxNode, true, 'LiteralSyntaxNode');
+        assertFlexibleHeredocLine(elements[2], text, '  ', null);
+      }),
+
+      new ParserTestArgs('<<<LABEL\n  a\n  LABEL;', 'should parse an indented line with literal', (statements, text) => {
+        let elements = assertFlexibleHeredocTemplate(statements);
+        assert.equal(elements.length, 3);
+        assertFlexibleHeredocLine(elements[0], text, '  ', 'a');
+        let lineBreak = <LiteralSyntaxNode>elements[1];
+        assert.equal(lineBreak instanceof LiteralSyntaxNode, true, 'LiteralSyntaxNode');
+        assertFlexibleHeredocLine(elements[2], text, '  ', null);
+      }),
+      new ParserTestArgs('<<<LABEL\n  $a\n  LABEL;', 'should parse an indented line with interpolation', (statements, text) => {
+        let elements = assertFlexibleHeredocTemplate(statements);
+        assert.equal(elements.length, 3);
+        let interpolations = assertFlexibleHeredocLine(elements[0], text, '  ');
+        let variable = <LocalVariableSyntaxNode>interpolations[0];
+        assert.equal(variable instanceof LocalVariableSyntaxNode, true);
+        Test.assertSyntaxToken(variable.variable, text, TokenKind.Variable, '$a');
+        let lineBreak = <LiteralSyntaxNode>elements[1];
+        assert.equal(lineBreak instanceof LiteralSyntaxNode, true, 'LiteralSyntaxNode');
+        assertFlexibleHeredocLine(elements[2], text, '  ', null);
+      }),
+      new ParserTestArgs('<<<LABEL\n  $a b\n  LABEL;', 'should parse an indented line with interpolation followed by literal', (statements, text) => {
+        let elements = assertFlexibleHeredocTemplate(statements);
+        assert.equal(elements.length, 3);
+
+        let interpolations = assertFlexibleHeredocLine(elements[0], text, '  ');
+        let variable = <LocalVariableSyntaxNode>interpolations[0];
+        assert.equal(variable instanceof LocalVariableSyntaxNode, true);
+        Test.assertSyntaxToken(variable.variable, text, TokenKind.Variable, '$a');
+        let literal = <LiteralSyntaxNode>interpolations[1];
+        Test.assertSyntaxToken(literal.value, text, TokenKind.StringTemplateLiteral, ' b');
+
+        let lineBreak = <LiteralSyntaxNode>elements[1];
+        assert.equal(lineBreak instanceof LiteralSyntaxNode, true, 'LiteralSyntaxNode');
+        assertFlexibleHeredocLine(elements[2], text, '  ', null);
+      }),
+      new ParserTestArgs('<<<LABEL\n  a $b\n  LABEL;', 'should parse an indented line with literal followed by interpolation', (statements, text) => {
+        let elements = assertFlexibleHeredocTemplate(statements);
+        assert.equal(elements.length, 3);
+
+        let interpolations = assertFlexibleHeredocLine(elements[0], text, '  ');
+        let literal = <LiteralSyntaxNode>interpolations[0];
+        Test.assertSyntaxToken(literal.value, text, TokenKind.StringTemplateLiteral, 'a ');
+        let variable = <LocalVariableSyntaxNode>interpolations[1];
+        assert.equal(variable instanceof LocalVariableSyntaxNode, true);
+        Test.assertSyntaxToken(variable.variable, text, TokenKind.Variable, '$b');
+
+        let lineBreak = <LiteralSyntaxNode>elements[1];
+        assert.equal(lineBreak instanceof LiteralSyntaxNode, true, 'LiteralSyntaxNode');
+        assertFlexibleHeredocLine(elements[2], text, '  ', null);
+      }),
+      new ParserTestArgs('<<<LABEL\n  $a$b\n  LABEL;', 'should parse an indented line with consecutive interpolations', (statements, text) => {
+        let elements = assertFlexibleHeredocTemplate(statements);
+        assert.equal(elements.length, 3);
+
+        let interpolations = assertFlexibleHeredocLine(elements[0], text, '  ');
+        let firstVariable = <LocalVariableSyntaxNode>interpolations[0];
+        assert.equal(firstVariable instanceof LocalVariableSyntaxNode, true);
+        Test.assertSyntaxToken(firstVariable.variable, text, TokenKind.Variable, '$a');
+        let secondVariable = <LocalVariableSyntaxNode>interpolations[1];
+        assert.equal(secondVariable instanceof LocalVariableSyntaxNode, true);
+        Test.assertSyntaxToken(secondVariable.variable, text, TokenKind.Variable, '$b');
+
+        let lineBreak = <LiteralSyntaxNode>elements[1];
+        assert.equal(lineBreak instanceof LiteralSyntaxNode, true, 'LiteralSyntaxNode');
+        assertFlexibleHeredocLine(elements[2], text, '  ', null);
+      }),
+
+      new ParserTestArgs('<<<LABEL\n  ${a}\n  LABEL;', 'should parse an indented line with indirection', (statements, text) => {
+        let elements = assertFlexibleHeredocTemplate(statements);
+        assert.equal(elements.length, 3);
+        let interpolations = assertFlexibleHeredocLine(elements[0], text, '  ');
+        let variable = <IndirectStringVariableSyntaxNode>interpolations[0];
+        assert.equal(variable instanceof IndirectStringVariableSyntaxNode, true);
+        let lineBreak = <LiteralSyntaxNode>elements[1];
+        assert.equal(lineBreak instanceof LiteralSyntaxNode, true, 'LiteralSyntaxNode');
+        assertFlexibleHeredocLine(elements[2], text, '  ', null);
+      }),
+      new ParserTestArgs('<<<LABEL\n  {$a}\n  LABEL;', 'should parse an indented line with interpolated expression', (statements, text) => {
+        let elements = assertFlexibleHeredocTemplate(statements);
+        assert.equal(elements.length, 3);
+        let interpolations = assertFlexibleHeredocLine(elements[0], text, '  ');
+        let strExpr = <StringExpressionSyntaxNode>interpolations[0];
+        assert.equal(strExpr instanceof StringExpressionSyntaxNode, true);
+        let lineBreak = <LiteralSyntaxNode>elements[1];
+        assert.equal(lineBreak instanceof LiteralSyntaxNode, true, 'LiteralSyntaxNode');
+        assertFlexibleHeredocLine(elements[2], text, '  ', null);
+      }),
+    ];
+    Test.assertSyntaxNodes(syntaxTests);
+
+    let diagnosticTests = [
+      new DiagnosticTestArgs('<<<LABEL\na\n  LABEL;', 'missing indent', [ErrorCode.ERR_IndentExpected], [9]),
+
+      // @todo Lexer tests.
+      new DiagnosticTestArgs('<<<LABEL\n\t\ta\n  LABEL;', 'should match indent of end label', [ErrorCode.ERR_HeredocIndentMismatch], [9]),
+      new DiagnosticTestArgs('<<<LABEL\n  a\n\t\tLABEL;', 'should match indent of end label (tabs)', [ErrorCode.ERR_HeredocIndentMismatch], [9]),
+      new DiagnosticTestArgs('<<<LABEL\n a\n  LABEL;', 'should not partially match indent of end label', [ErrorCode.ERR_HeredocIndentMismatch], [9]),
+      new DiagnosticTestArgs('<<<LABEL\n\ta\n\t\tLABEL;', 'should not partially match indent of end label (tabs)', [ErrorCode.ERR_HeredocIndentMismatch], [9]),
+      new DiagnosticTestArgs('<<<LABEL\n \ta\n \tLABEL;', 'should not contain spaces and tabs', [ErrorCode.ERR_HeredocIndentHasSpacesAndTabs], [13]),
+
+      // @todo Recovery tests.
+      new DiagnosticTestArgs('<<<LABEL\n  {$a $b}\n  LABEL;', 'missing close brace (in malformed interpolation)', [ErrorCode.ERR_CloseBraceExpected], [14]),
+    ];
+    Test.assertDiagnostics(diagnosticTests);
   });
 
 });

--- a/test/src/parser/PhpParserTest_FunctionDeclaration.ts
+++ b/test/src/parser/PhpParserTest_FunctionDeclaration.ts
@@ -267,6 +267,8 @@ describe('PhpParser', function() {
       new DiagnosticTestArgs('function a(B', 'missing ampersand, ellipsis, or variable', [ErrorCode.ERR_VariableExpected], [12]),
       // @todo Improve error message.
       new DiagnosticTestArgs('function a($b', 'missing comma, close paren, or equals', [ErrorCode.ERR_CloseParenExpected], [13]),
+      // @todo Improve error message.
+      new DiagnosticTestArgs('function a($b,', 'missing ampersand, ellipsis, question, type, or variable', [ErrorCode.ERR_VariableExpected], [14]),
       new DiagnosticTestArgs('function a(...', 'missing variable', [ErrorCode.ERR_VariableExpected], [14]),
       new DiagnosticTestArgs('function a(...$b', 'missing close paren', [ErrorCode.ERR_CloseParenExpected], [16]),
 

--- a/test/src/parser/PhpParserTest_Statements.ts
+++ b/test/src/parser/PhpParserTest_Statements.ts
@@ -381,21 +381,42 @@ describe('PhpParser', function() {
       new ParserTestArgs('unset($a);', 'should parse an unset statement', (statements, text) => {
         let unsetNode = <UnsetSyntaxNode>statements[0];
         assert.equal(unsetNode instanceof UnsetSyntaxNode, true, 'UnsetSyntaxNode');
-        let variables = unsetNode.expressionList.childNodes();
-        assert.equal(variables.length, 1);
-        let variable = <LocalVariableSyntaxNode>variables[0];
+        let expressions = unsetNode.expressionList.childNodes();
+        assert.equal(expressions.length, 1);
+        let variable = <LocalVariableSyntaxNode>expressions[0];
         assert.equal(variable instanceof LocalVariableSyntaxNode, true);
         Test.assertSyntaxToken(variable.variable, text, TokenKind.Variable, '$a');
       }),
-      new ParserTestArgs('unset($a, $b);', 'should parse an unset statement with multiple variables', (statements, text) => {
+      new ParserTestArgs('unset($a, $b);', 'should parse an unset statement with expression list', (statements, text) => {
         let unsetNode = <UnsetSyntaxNode>statements[0];
         assert.equal(unsetNode instanceof UnsetSyntaxNode, true, 'UnsetSyntaxNode');
-        let variables = unsetNode.expressionList.childNodes();
-        assert.equal(variables.length, 2);
-        let firstVariable = <LocalVariableSyntaxNode>variables[0];
+        let expressions = unsetNode.expressionList.childNodes();
+        assert.equal(expressions.length, 2);
+        let firstVariable = <LocalVariableSyntaxNode>expressions[0];
         assert.equal(firstVariable instanceof LocalVariableSyntaxNode, true);
         Test.assertSyntaxToken(firstVariable.variable, text, TokenKind.Variable, '$a');
-        let secondVariable = <LocalVariableSyntaxNode>variables[0];
+        let secondVariable = <LocalVariableSyntaxNode>expressions[0];
+        assert.equal(secondVariable instanceof LocalVariableSyntaxNode, true);
+        Test.assertSyntaxToken(secondVariable.variable, text, TokenKind.Variable, '$a');
+      }),
+      new ParserTestArgs('unset($a,);', 'should parse an unset statement with trailing comma', (statements, text) => {
+        let unsetNode = <UnsetSyntaxNode>statements[0];
+        assert.equal(unsetNode instanceof UnsetSyntaxNode, true, 'UnsetSyntaxNode');
+        let expressions = unsetNode.expressionList.childNodes();
+        assert.equal(expressions.length, 1);
+        let variable = <LocalVariableSyntaxNode>expressions[0];
+        assert.equal(variable instanceof LocalVariableSyntaxNode, true);
+        Test.assertSyntaxToken(variable.variable, text, TokenKind.Variable, '$a');
+      }),
+      new ParserTestArgs('unset($a, $b,);', 'should parse an unset statement with trailing comma after expression list', (statements, text) => {
+        let unsetNode = <UnsetSyntaxNode>statements[0];
+        assert.equal(unsetNode instanceof UnsetSyntaxNode, true, 'UnsetSyntaxNode');
+        let expressions = unsetNode.expressionList.childNodes();
+        assert.equal(expressions.length, 2);
+        let firstVariable = <LocalVariableSyntaxNode>expressions[0];
+        assert.equal(firstVariable instanceof LocalVariableSyntaxNode, true);
+        Test.assertSyntaxToken(firstVariable.variable, text, TokenKind.Variable, '$a');
+        let secondVariable = <LocalVariableSyntaxNode>expressions[0];
         assert.equal(secondVariable instanceof LocalVariableSyntaxNode, true);
         Test.assertSyntaxToken(secondVariable.variable, text, TokenKind.Variable, '$a');
       }),
@@ -406,7 +427,8 @@ describe('PhpParser', function() {
       new DiagnosticTestArgs('unset', 'missing open paren', [ErrorCode.ERR_OpenParenExpected], [5]),
       new DiagnosticTestArgs('unset(', 'missing expression', [ErrorCode.ERR_ExpressionExpectedEOF], [6]),
       new DiagnosticTestArgs('unset($a', 'missing comma or close paren', [ErrorCode.ERR_CommaOrCloseParenExpected], [8]),
-      new DiagnosticTestArgs('unset($a,', 'missing expression after comma', [ErrorCode.ERR_ExpressionExpectedEOF], [9]),
+      new DiagnosticTestArgs('unset($a,', 'missing expression or close paren', [ErrorCode.ERR_ExpressionOrCloseParenExpected], [9]),
+      new DiagnosticTestArgs('unset($a, $b,', 'missing expression or close paren (in list)', [ErrorCode.ERR_ExpressionOrCloseParenExpected], [13]),
       new DiagnosticTestArgs('unset(1);', 'should expect an explicit expression', [ErrorCode.ERR_ExpressionNotAddressable], [6]),
     ];
     Test.assertDiagnostics(diagnosticTests);

--- a/test/src/parser/PhpParserTest_Statements_Jump.ts
+++ b/test/src/parser/PhpParserTest_Statements_Jump.ts
@@ -142,8 +142,7 @@ describe('PhpParser', function() {
       Test.assertSyntaxNodes(tests);
 
       let diagnosticTests = [
-        // @todo "Expression or ';' expected"
-        new DiagnosticTestArgs('return', 'missing expression or semicolon', [ErrorCode.ERR_SemicolonExpected], [6]),
+        new DiagnosticTestArgs('return', 'missing expression or semicolon', [ErrorCode.ERR_ExpressionOrSemicolonExpected], [6]),
         new DiagnosticTestArgs('return 1', 'missing semicolon', [ErrorCode.ERR_SemicolonExpected], [8]),
       ];
       Test.assertDiagnostics(diagnosticTests);


### PR DESCRIPTION
This PR tracks the following PHP 7.3 changes:
- [x] [trailing comma in function calls](https://wiki.php.net/rfc/trailing-comma-function-calls)
- [x] [list() reference assignment](https://wiki.php.net/rfc/list_reference_assignment)
- [x] [flexible heredoc syntax](https://wiki.php.net/rfc/flexible_heredoc_nowdoc_syntaxes)