### PR TITLE
PHP 7.4

### DIFF
--- a/src/language/TokenKind.ts
+++ b/src/language/TokenKind.ts
@@ -138,6 +138,7 @@ export enum TokenKind {
   BooleanAnd,               // "&&"
   BooleanOr,                // "||"
   Coalesce,
+  CoalesceEqual,
   ConcatEqual,
   Decrement,
   DivideEqual,
@@ -460,6 +461,8 @@ export class TokenKindInfo {
         return '||';
       case TokenKind.Coalesce:
         return '??';
+      case TokenKind.CoalesceEqual:
+        return '??=';
       case TokenKind.ConcatEqual:
         return '.=';
       case TokenKind.Decrement:

--- a/src/parser/PhpLexer.ts
+++ b/src/parser/PhpLexer.ts
@@ -1043,8 +1043,14 @@ export class PhpLexer extends LexerBase<Token, PhpLexerState> {
           return this.state = PhpLexerState.InHostLanguage;
         }
         else if (next == Character.Question) {
-          this.offset = this.offset + 2; // "??"
-          this.tokenKind = TokenKind.Coalesce;
+          if (this.peek(this.offset + 2) == Character.Equal && this.phpVersion >= PhpVersion.PHP7_4) {
+            this.offset = this.offset + 3;  // "??="
+            this.tokenKind = TokenKind.CoalesceEqual;
+          }
+          else {
+            this.offset = this.offset + 2;  // "??"
+            this.tokenKind = TokenKind.Coalesce;
+          }
         }
         else {
           this.offset++;

--- a/src/parser/PhpParser.ts
+++ b/src/parser/PhpParser.ts
@@ -755,6 +755,7 @@ export class PhpParser implements IParser<SourceTextSyntaxNode> {
   protected isAssignmentOperator(kind: TokenKind): boolean {
     switch (kind) {
       case TokenKind.AndEqual:
+      case TokenKind.CoalesceEqual:
       case TokenKind.ConcatEqual:
       case TokenKind.DivideEqual:
       case TokenKind.Equal:
@@ -1079,6 +1080,7 @@ export class PhpParser implements IParser<SourceTextSyntaxNode> {
       case TokenKind.Pow:
       // Assignment operators.
       case TokenKind.AndEqual:
+      case TokenKind.CoalesceEqual:
       case TokenKind.ConcatEqual:
       case TokenKind.DivideEqual:
       case TokenKind.Equal:
@@ -6253,6 +6255,7 @@ export class PhpParser implements IParser<SourceTextSyntaxNode> {
       case TokenKind.LogicalAnd:
         return Precedence.LogicalAnd;
       case TokenKind.AndEqual:
+      case TokenKind.CoalesceEqual:
       case TokenKind.ConcatEqual:
       case TokenKind.DivideEqual:
       case TokenKind.Equal:

--- a/src/parser/PhpVersion.ts
+++ b/src/parser/PhpVersion.ts
@@ -26,7 +26,8 @@ export enum PhpVersion {
   PHP7_1,
   PHP7_2,
   PHP7_3,
-  Latest = PHP7_3
+  PHP7_4,
+  Latest = PHP7_4
 
 }
 
@@ -48,6 +49,8 @@ export class PhpVersionInfo {
         return '7.2';
       case PhpVersion.PHP7_3:
         return '7.3';
+      case PhpVersion.PHP7_4:
+        return '7.4';
       default:
         return '';
     }

--- a/test/src/Test.ts
+++ b/test/src/Test.ts
@@ -84,6 +84,8 @@ export class Test {
         return PhpVersion.PHP7_2;
       case '7_3':
         return PhpVersion.PHP7_3;
+      case '7_4':
+        return PhpVersion.PHP7_4;
       default:
         return PhpVersion.Latest;
     }

--- a/test/src/parser/PhpLexerTest.ts
+++ b/test/src/parser/PhpLexerTest.ts
@@ -277,6 +277,11 @@ describe('PhpLexer', function() {
         new LexerTestArgs('<?php ->', 'object operator', [TokenKind.ObjectOperator]),
       ];
       Test.assertTokens(tests);
+
+      let tests7_4 = [
+        new LexerTestArgs('<?php ??=', 'coalesce equal', [TokenKind.CoalesceEqual]),
+      ];
+      Test.assertTokens(tests7_4, PhpVersion.PHP7_4);
     });
 
     describe('type casts', function() {

--- a/test/src/parser/PhpParserTest_Expressions_Binary.ts
+++ b/test/src/parser/PhpParserTest_Expressions_Binary.ts
@@ -249,6 +249,13 @@ describe('PhpParser', function() {
         }),
       ];
       Test.assertSyntaxNodes(syntaxTests);
+
+      let syntaxTests7_4 = [
+        new ParserTestArgs('$a ??= $b ??= 1;', 'coalesce equal', (statements) => {
+          assertAssignmentAssociativity(statements);
+        }),
+      ];
+      Test.assertSyntaxNodes(syntaxTests7_4, PhpVersion.PHP7_4);
     });
 
     describe('non-associative operators', function() {
@@ -812,6 +819,14 @@ describe('PhpParser', function() {
         }),
       ];
       Test.assertSyntaxNodes(syntaxTests);
+
+      let syntaxTests7_4 = [
+        new ParserTestArgs('$a ??= 2;', 'should parse a coalesce equals expression', (statements, text) => {
+          let assignment = assertAssignmentNode(statements);
+          Test.assertSyntaxToken(assignment.operator, text, TokenKind.CoalesceEqual, '??=');
+        }),
+      ];
+      Test.assertSyntaxNodes(syntaxTests7_4, PhpVersion.PHP7_4);
     });
 
   });


### PR DESCRIPTION
This PR tracks the following PHP 7.4 changes:
- [x] [null coalescing assignments](https://wiki.php.net/rfc/null_coalesce_equal_operator)
- [ ] [typed properties](https://wiki.php.net/rfc/typed_properties_v2)