### PR TITLE
PHP 8.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x]
+        node-version: [12.x, 14.x]
         php-version: [8_0, 7_4, 7_3, 7_2, 7_1, 7_0]
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         node-version: [12.x]
-        php-version: [7_4, 7_3, 7_2, 7_1, 7_0]
+        php-version: [8_0, 7_4, 7_3, 7_2, 7_1, 7_0]
 
     steps:
       - uses: actions/checkout@v2

--- a/src/diagnostics.yaml
+++ b/src/diagnostics.yaml
@@ -330,6 +330,8 @@ diagnostics:
   text: "Variable expected"
 - name: ERR_VariableNameExpected
   text: "Variable name expected after '$'"
+- name: ERR_VariableOrAmpersandExpected
+  text: "Variable or '&' expected"
 - name: ERR_VariableOrEllipsisExpected
   text: "Variable or '...' expected"
 - name: ERR_VariadicHasDefaultValue

--- a/src/diagnostics.yaml
+++ b/src/diagnostics.yaml
@@ -69,6 +69,8 @@ diagnostics:
   text: "The feature 'constructor parameter promotion' requires PHP 8.0 or later"
 - name: ERR_FeatureTrailingCommasInClosureUseLists
   text: "The feature 'trailing commas in closure use lists' requires PHP 8.0 or later"
+- name: ERR_FeatureUnionTypes
+  text: "The feature 'union types' requires PHP 8.0 or later"
 
 # -----------------------------------------------------------------------------
 # Lexer diagnostics
@@ -367,3 +369,5 @@ diagnostics:
   text: "Variable, '&' or ')' expected"
 - name: ERR_TryCatchUnionOrOptionalVariableExpected
   text: "Type union, variable, or ')' expected"
+- name: ERR_TypeUnionHasNullableType
+  text: "Nullable types cannot be used in a type union"

--- a/src/diagnostics.yaml
+++ b/src/diagnostics.yaml
@@ -71,6 +71,8 @@ diagnostics:
   text: "The feature 'static return type' requires PHP 8.0 or later"
 - name: ERR_FeatureTrailingCommasInClosureUseLists
   text: "The feature 'trailing commas in closure use lists' requires PHP 8.0 or later"
+- name: ERR_FeatureTrailingCommasInParameterLists
+  text: "The feature 'trailing commas in parameter lists' requires PHP 8.0 or later"
 - name: ERR_FeatureUnionTypes
   text: "The feature 'union types' requires PHP 8.0 or later"
 

--- a/src/diagnostics.yaml
+++ b/src/diagnostics.yaml
@@ -67,6 +67,8 @@ diagnostics:
 # --- PHP 8.0 -----------------------------------------------------------------
 - name: ERR_FeatureConstructorParameterPromotion
   text: "The feature 'constructor parameter promotion' requires PHP 8.0 or later"
+- name: ERR_FeatureStaticReturnType
+  text: "The feature 'static return type' requires PHP 8.0 or later"
 - name: ERR_FeatureTrailingCommasInClosureUseLists
   text: "The feature 'trailing commas in closure use lists' requires PHP 8.0 or later"
 - name: ERR_FeatureUnionTypes

--- a/src/diagnostics.yaml
+++ b/src/diagnostics.yaml
@@ -67,6 +67,8 @@ diagnostics:
 # --- PHP 8.0 -----------------------------------------------------------------
 - name: ERR_FeatureConstructorParameterPromotion
   text: "The feature 'constructor parameter promotion' requires PHP 8.0 or later"
+- name: ERR_FeatureNamedArguments
+  text: "The feature 'named arguments' requires PHP 8.0 or later"
 - name: ERR_FeatureStaticReturnType
   text: "The feature 'static return type' requires PHP 8.0 or later"
 - name: ERR_FeatureTrailingCommasInClosureUseLists
@@ -136,7 +138,7 @@ diagnostics:
 - name: ERR_AbstractMethodHasBody
   text: "An abstract method cannot have a body"
 - name: ERR_ArgumentAfterUnpack
-  text: "A positional argument must be used prior to unpacked arguments"
+  text: "Positional and named arguments must be used prior to unpacked arguments"
 - name: ERR_BadConstantModifier
   text: "Class constants cannot be abstract, final, or static"
 - name: ERR_BadInterfaceModifier

--- a/src/diagnostics.yaml
+++ b/src/diagnostics.yaml
@@ -64,6 +64,10 @@ diagnostics:
 - name: ERR_FeatureTypedProperties
   text: "The feature 'typed properties' requires PHP 7.4 or later"
 
+# --- PHP 8.0 -----------------------------------------------------------------
+- name: ERR_FeatureTrailingCommasInClosureUseLists
+  text: "The feature 'trailing commas in closure use lists' requires PHP 8.0 or later"
+
 # -----------------------------------------------------------------------------
 # Lexer diagnostics
 # -----------------------------------------------------------------------------
@@ -357,5 +361,7 @@ diagnostics:
   severity: 2
 
 # --- PHP 8.0 -----------------------------------------------------------------
+- name: ERR_IncompleteClosureUseList
+  text: "Variable, '&' or ')' expected"
 - name: ERR_TryCatchUnionOrOptionalVariableExpected
   text: "Type union, variable, or ')' expected"

--- a/src/diagnostics.yaml
+++ b/src/diagnostics.yaml
@@ -65,6 +65,8 @@ diagnostics:
   text: "The feature 'typed properties' requires PHP 7.4 or later"
 
 # --- PHP 8.0 -----------------------------------------------------------------
+- name: ERR_FeatureConstructorParameterPromotion
+  text: "The feature 'constructor parameter promotion' requires PHP 8.0 or later"
 - name: ERR_FeatureTrailingCommasInClosureUseLists
   text: "The feature 'trailing commas in closure use lists' requires PHP 8.0 or later"
 

--- a/src/diagnostics.yaml
+++ b/src/diagnostics.yaml
@@ -353,3 +353,7 @@ diagnostics:
 - name: WRN_UnsetCast
   text: "The '(unset)' type cast is deprecated, use 'null' instead"
   severity: 2
+
+# --- PHP 8.0 -----------------------------------------------------------------
+- name: ERR_TryCatchUnionOrOptionalVariableExpected
+  text: "Type union, variable, or ')' expected"

--- a/src/language/TokenKind.ts
+++ b/src/language/TokenKind.ts
@@ -82,6 +82,7 @@ export enum TokenKind {
   MagicMethod,              // T_METHOD_C
   MagicNamespace,           // T_NS_C
   MagicTrait,               // T_TRAIT_C
+  Match,
   Namespace,
   New,
   Print,
@@ -357,6 +358,8 @@ export class TokenKindInfo {
         return '__namespace__';
       case TokenKind.MagicTrait:
         return '__trait__';
+      case TokenKind.Match:
+        return 'match';
       case TokenKind.Namespace:
         return 'namespace';
       case TokenKind.New:

--- a/src/language/TokenKind.ts
+++ b/src/language/TokenKind.ts
@@ -158,6 +158,7 @@ export enum TokenKind {
   MinusEqual,
   ModEqual,
   MultiplyEqual,
+  NullSafeObjectOperator,
   ObjectOperator,
   OpenBraceDollar,          // Not used.
   OrEqual,
@@ -502,6 +503,8 @@ export class TokenKindInfo {
         return '%=';
       case TokenKind.MultiplyEqual:
         return '*=';
+      case TokenKind.NullSafeObjectOperator:
+        return '?->';
       case TokenKind.ObjectOperator:
         return '->';
       case TokenKind.OpenBraceDollar:

--- a/src/nodes.yaml
+++ b/src/nodes.yaml
@@ -747,6 +747,14 @@ nodes:
   - name: closeQuote
     type: TokenNode
   visitorName: visitStringTemplate
+- name: ThrowExpression
+  extends: Expression
+  properties:
+  - name: throwKeyword
+    type: TokenNode
+  - name: expression
+    type: Expression
+  visitorName: visitThrowExpression
 - name: Unary
   extends: Expression
   properties:

--- a/src/nodes.yaml
+++ b/src/nodes.yaml
@@ -874,15 +874,6 @@ nodes:
   - name: semicolon
     type: TokenNode
   visitorName: visitContinue
-- name: ExpressionStatement
-  extends: Statement
-  properties:
-  - name: expression
-    type: Expression
-    optional: true
-  - name: semicolon
-    type: TokenNode
-  visitorName: visitExpressionStatement
 - name: Declare
   extends: Statement
   properties:
@@ -949,6 +940,15 @@ nodes:
     type: TokenNode
     optional: true
   visitorName: visitEcho
+- name: ExpressionStatement
+  extends: Statement
+  properties:
+  - name: expression
+    type: Expression
+    optional: true
+  - name: semicolon
+    type: TokenNode
+  visitorName: visitExpressionStatement
 - name: For
   extends: Iteration
   properties:

--- a/src/nodes.yaml
+++ b/src/nodes.yaml
@@ -1920,6 +1920,7 @@ nodes:
     type: NodeList
   - name: variable
     type: TokenNode
+    optional: true
   - name: closeParen
     type: TokenNode
   - name: statements

--- a/src/nodes.yaml
+++ b/src/nodes.yaml
@@ -1835,6 +1835,9 @@ nodes:
   visitorType: Type
 - name: Parameter
   properties:
+  - name: modifiers
+    type: NodeList
+    optional: true
   - name: type
     type:
     - NamedType

--- a/src/nodes.yaml
+++ b/src/nodes.yaml
@@ -1558,6 +1558,12 @@ nodes:
 # Clauses
 # -----------------------------------------------------------------------------
 
+# Used by named and positional arguments.
+- name: Argument
+  abstract: true
+  properties:
+  - name: value
+    type: Expression
 # Used by fully qualified, partially qualified, and relative names.
 - name: Name
   abstract: true
@@ -1626,14 +1632,6 @@ nodes:
   - name: closeBrace
     type: TokenNode
   visitorName: visitAnonymousClass
-- name: Argument
-  properties:
-  - name: ellipsis
-    type: TokenNode
-    optional: true
-  - name: value
-    type: Expression
-  visitorName: visitArgument
 - name: ArrayElement
   properties:
   - name: key
@@ -1823,6 +1821,19 @@ nodes:
   - name: methodName
     type: TokenNode
   visitorName: visitMethodReference
+# See also: PositionalArgument
+- name: NamedArgument
+  extends: Argument
+  properties:
+  - name: identifier
+    type: TokenNode
+  - name: colon
+    type: TokenNode
+  - name: value
+    type: Expression
+    inherited: true
+  visitorName: visitArgument
+  visitorType: Argument
 # See also: ReferencedTraitAlias
 - name: NamedTraitAlias
   extends: TraitAlias
@@ -1891,6 +1902,18 @@ nodes:
     type: NodeList
     inherited: true
   visitorName: visitPartiallyQualifiedName
+# See also: NamedArgument
+- name: PositionalArgument
+  extends: Argument
+  properties:
+  - name: ellipsis
+    type: TokenNode
+    optional: true
+  - name: value
+    type: Expression
+    inherited: true
+  visitorName: visitArgument
+  visitorType: Argument
 # See also: NamedType
 - name: PredefinedType
   extends: NullableType

--- a/src/nodes.yaml
+++ b/src/nodes.yaml
@@ -132,6 +132,7 @@ nodes:
     type:
     - NamedType
     - PredefinedType
+    - CompositeType
     optional: true
   - name: statements
     type: StatementBlock
@@ -184,6 +185,7 @@ nodes:
     type:
     - NamedType
     - PredefinedType
+    - CompositeType
     optional: true
   - name: doubleArrow
     type: TokenNode
@@ -1114,6 +1116,7 @@ nodes:
     type:
     - NamedType
     - PredefinedType
+    - CompositeType
     optional: true
   - name: statements
     type: StatementBlock
@@ -1263,6 +1266,7 @@ nodes:
     type:
     - NamedType
     - PredefinedType
+    - CompositeType
     optional: true
   - name: statements
     type: StatementBlock
@@ -1307,6 +1311,7 @@ nodes:
     type:
     - NamedType
     - PredefinedType
+    - CompositeType
     optional: true
   - name: properties
     type: NodeList
@@ -1551,6 +1556,14 @@ nodes:
   properties:
   - name: namespaceName
     type: NodeList
+# Used by named and predefined types.
+- name: NullableType
+  abstract: true
+  extends: Type
+  properties:
+  - name: question
+    type: TokenNode
+    optional: true
 - name: Pattern
   abstract: true
 # Used by named and referenced trait aliases.
@@ -1569,10 +1582,6 @@ nodes:
     type: TokenNode
 - name: Type
   abstract: true
-  properties:
-  - name: question
-    type: TokenNode
-    optional: true
 
 # -----------------------------------------------------------------------------
 
@@ -1652,6 +1661,13 @@ nodes:
   - name: closeParen
     type: TokenNode
   visitorName: visitClosureUse
+- name: CompositeType
+  extends: Type
+  properties:
+  - name: types
+    type: NodeList
+  visitorName: visitType
+  visitorType: Type
 # Unlike ClassConstantElement, the name cannot be a semi-reserved keyword.
 - name: ConstantElement
   properties:
@@ -1823,7 +1839,7 @@ nodes:
   visitorType: TraitAlias
 # See also: PredefinedType
 - name: NamedType
-  extends: Type
+  extends: NullableType
   properties:
   - name: question
     type: TokenNode
@@ -1842,6 +1858,7 @@ nodes:
     type:
     - NamedType
     - PredefinedType
+    - CompositeType
     optional: true
   - name: ampersand
     type: TokenNode
@@ -1868,7 +1885,7 @@ nodes:
   visitorName: visitPartiallyQualifiedName
 # See also: NamedType
 - name: PredefinedType
-  extends: Type
+  extends: NullableType
   properties:
   - name: question
     type: TokenNode

--- a/src/nodes.yaml
+++ b/src/nodes.yaml
@@ -548,6 +548,25 @@ nodes:
   - name: variable
     type: TokenNode
   visitorName: visitLocalVariable
+- name: Match
+  extends: Expression
+  properties:
+  - name: matchKeyword
+    type: TokenNode
+  - name: openParen
+    type: TokenNode
+  - name: expression
+    type: Expression
+  - name: closeParen
+    type: TokenNode
+  - name: openBrace
+    type: TokenNode
+  - name: arms
+    type: NodeList
+    optional: true
+  - name: closeBrace
+    type: TokenNode
+  visitorName: visitMatch
 - name: NamedMemberAccess
   extends: MemberAccess
   properties:
@@ -1532,6 +1551,8 @@ nodes:
   properties:
   - name: namespaceName
     type: NodeList
+- name: Pattern
+  abstract: true
 # Used by named and referenced trait aliases.
 - name: TraitAlias
   abstract: true
@@ -1641,6 +1662,16 @@ nodes:
   - name: expression
     type: Expression
   visitorName: visitConstantElement
+# This is also known as the discard pattern in other languages. Only time will
+# tell if PHP's maintainers consistently use the default keyword or adopt the
+# underscore token like those languages in future use-cases.
+- name: DefaultPattern
+  extends: Pattern
+  properties:
+  - name: defaultKeyword
+    type: TokenNode
+  visitorName: visitPattern
+  visitorType: Pattern
 - name: Else
   properties:
   - name: elseKeyword
@@ -1687,6 +1718,13 @@ nodes:
     type: NodeList
     optional: true
   visitorName: visitElseIfBlock
+- name: ExpressionPattern
+  extends: Pattern
+  properties:
+  - name: expression
+    type: Expression
+  visitorName: visitPattern
+  visitorType: Pattern
 - name: FlexibleHeredocElement
   properties:
   - name: indent
@@ -1742,6 +1780,15 @@ nodes:
     - Expression
     - ListDestructure
   visitorName: visitListDestructureElement
+- name: MatchArm
+  properties:
+  - name: patterns
+    type: NodeList
+  - name: doubleArrow
+    type: TokenNode
+  - name: expression
+    type: Expression
+  visitorName: visitMatchArm
 # See also: TraitAlias, TraitPrecedence
 - name: MethodReference
   properties:

--- a/src/parser/ExpressionType.ts
+++ b/src/parser/ExpressionType.ts
@@ -19,7 +19,7 @@
 /**
  * The "value categories" of an expression.
  *
- * For those familiar with C++, this is similar its `lvalue` and `rvalue`
+ * For those familiar with C++, this is similar to its `lvalue` and `rvalue`
  * categories (which are actually much more complicated), but instead of
  * being used to handle temporary objects, it is used to determine which
  * action the parser should take.

--- a/src/parser/PhpLexer.ts
+++ b/src/parser/PhpLexer.ts
@@ -123,6 +123,7 @@ export class PhpLexer extends LexerBase<Token, PhpLexerState> {
     ['interface', TokenKind.Interface],
     ['isset', TokenKind.IsSet],
     ['list', TokenKind.List],
+    ['match', TokenKind.Match],
     ['namespace', TokenKind.Namespace],
     ['new', TokenKind.New],
     ['or', TokenKind.LogicalOr],
@@ -2221,10 +2222,15 @@ export class PhpLexer extends LexerBase<Token, PhpLexerState> {
     const keyword = PhpLexer.KeywordTokens.get(tokenText);
     if (keyword !== undefined) {
       // Backward compatibility: Am I a joke to you?
-      if (tokenText === 'fn' && this.phpVersion < PhpVersion.PHP7_4) {
+      if (this.phpVersion < PhpVersion.PHP7_4 && tokenText === 'fn') {
         return TokenKind.Identifier;
       }
-      return keyword;
+      else if (this.phpVersion < PhpVersion.PHP8_0 && tokenText === 'match') {
+        return TokenKind.Identifier;
+      }
+      else {
+        return keyword;
+      }
     }
     return TokenKind.Identifier;
   }

--- a/src/parser/PhpLexer.ts
+++ b/src/parser/PhpLexer.ts
@@ -491,6 +491,19 @@ export class PhpLexer extends LexerBase<Token, PhpLexerState> {
   }
 
   /**
+   * Determines if the text is a type used by a cast token.
+   */
+  protected isCastToken(text: string): boolean {
+    if (PhpLexer.CastTokens.has(text)) {
+      if (text === 'real' || text === 'unset') {
+        return this.phpVersion < PhpVersion.PHP8_0;
+      }
+      return true;
+    }
+    return false;
+  }
+
+  /**
    * Tokenizes a starting or ending heredoc label.
    */
   protected lexHeredocLabel(): PhpLexerState {
@@ -2379,7 +2392,7 @@ export class PhpLexer extends LexerBase<Token, PhpLexerState> {
       // It's still not a cast until we get a closing parenthesis.
       if (this.peek(this.offset) === Character.CloseParen) {
         let type = this.text.substring(typeStart, length).toLowerCase();
-        if (PhpLexer.CastTokens.has(type)) {
+        if (this.isCastToken(type)) {
           this.offset++;  // ")"
           // Suppress TS2322: Result cannot be undefined due to if-condition.
           this.tokenKind = <TokenKind>PhpLexer.CastTokens.get(type);

--- a/src/parser/PhpParser.ts
+++ b/src/parser/PhpParser.ts
@@ -1872,7 +1872,7 @@ export class PhpParser implements IParser<SourceTextSyntaxNode> {
    */
   protected parseClassMemberDeclaration(context: ParseContext): StatementNode {
     // Anything that is not a modifier should have been handled by the caller.
-    Debug.assert(this.getModifierFlag(this.currentToken.kind) !== ModifierFlags.None);
+    Debug.assert(this.isModifier(this.currentToken.kind));
 
     let modifiers: TokenNode[] = [];
     let modifierFlags = this.parseClassMemberModifiers(modifiers, context);
@@ -6910,7 +6910,7 @@ export class PhpParser implements IParser<SourceTextSyntaxNode> {
       case TokenKind.Function:
         return true;
       default:
-        return this.getModifierFlag(this.currentToken.kind) !== ModifierFlags.None;
+        return this.isModifier(this.currentToken.kind);
     }
   }
 

--- a/src/parser/PhpParser.ts
+++ b/src/parser/PhpParser.ts
@@ -6889,13 +6889,6 @@ export class PhpParser implements IParser<SourceTextSyntaxNode> {
   }
 
   /**
-   * Determines if a parameter is entirely missing.
-   */
-  protected isParameterMissing(parameter: ParameterNode): boolean {
-    return parameter.ampersand === null && parameter.ellipsis === null && parameter.variable.isMissing;
-  }
-
-  /**
    * Determines if the next token may start a member declaration and is on a
    * different line.
    */

--- a/src/parser/PhpParser.ts
+++ b/src/parser/PhpParser.ts
@@ -1071,6 +1071,7 @@ export class PhpParser implements IParser<SourceTextSyntaxNode> {
    * Determines if a token starts a property declaration.
    */
   protected isPropertyStart(kind: TokenKind): boolean {
+    // The '$' token is also allowed for error recovery purposes.
     return kind === TokenKind.Dollar || kind === TokenKind.Variable || this.isTypeStart(kind);
   }
 
@@ -5566,9 +5567,19 @@ export class PhpParser implements IParser<SourceTextSyntaxNode> {
    */
   protected parseLexicalVariable(): LexicalVariableNode {
     let ampersand = this.eatOptional(TokenKind.Ampersand);
-    let variable = this.currentToken.kind === TokenKind.Variable
-      ? this.eat(TokenKind.Variable)
-      : this.createMissingTokenWithError(TokenKind.Variable, ErrorCode.ERR_VariableExpected);
+    let variable: TokenNode;
+    if (this.currentToken.kind === TokenKind.Variable) {
+      variable = this.eat(TokenKind.Variable);
+    }
+    else if (this.currentToken.kind === TokenKind.Dollar) {
+      variable = this.eat(TokenKind.Dollar);
+      variable = this.addError(variable, ErrorCode.ERR_VariableNameExpected);
+    }
+    else {
+      variable = ampersand === null
+        ? this.createMissingTokenWithError(TokenKind.Variable, ErrorCode.ERR_VariableOrAmpersandExpected)
+        : this.createMissingTokenWithError(TokenKind.Variable, ErrorCode.ERR_VariableExpected);
+    }
     return new LexicalVariableNode(ampersand, variable);
   }
 

--- a/src/parser/PhpParser.ts
+++ b/src/parser/PhpParser.ts
@@ -6464,11 +6464,12 @@ export class PhpParser implements IParser<SourceTextSyntaxNode> {
       case TokenKind.IsLessThanOrEqual:
       case TokenKind.LessThan:
         return Precedence.Relational;
+      case TokenKind.Period:
+        return this.isSupportedVersion(PhpVersion.PHP8_0) ? Precedence.Concatenate : Precedence.Add;
       case TokenKind.ShiftLeft:
       case TokenKind.ShiftRight:
         return Precedence.Shift;
       case TokenKind.Minus:
-      case TokenKind.Period:
       case TokenKind.Plus:
         return Precedence.Add;
       case TokenKind.Asterisk:

--- a/src/parser/PhpVersion.ts
+++ b/src/parser/PhpVersion.ts
@@ -27,7 +27,8 @@ export enum PhpVersion {
   PHP7_2,
   PHP7_3,
   PHP7_4,
-  Latest = PHP7_4
+  PHP8_0,
+  Latest = PHP8_0
 
 }
 
@@ -51,6 +52,8 @@ export class PhpVersionInfo {
         return '7.3';
       case PhpVersion.PHP7_4:
         return '7.4';
+      case PhpVersion.PHP8_0:
+        return '8.0';
       default:
         return '';
     }

--- a/src/parser/Precedence.ts
+++ b/src/parser/Precedence.ts
@@ -41,8 +41,9 @@ export enum Precedence {
   BitwiseAnd,
   Equality,     // Is equal, is identical, spaceship, etc.
   Relational,   // Less than, greater than, etc.
+  Concatenate,
   Shift,
-  Add,          // Add, subtract, and concatenate.
+  Add,          // Add and subtract.
   Multiply,     // Multiply, divide, and modulus.
   LogicalNot,   // "!"
   InstanceOf,

--- a/src/parser/ResetPoint.ts
+++ b/src/parser/ResetPoint.ts
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2017 Matt Acosta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+import { ParseContext } from './ParseContext';
+
+export class ResetPoint<T> {
+
+  public readonly context: ParseContext;
+
+  public readonly lexerState: T;
+
+  public readonly offset: number;
+
+  constructor(context: ParseContext, lexerState: T, offset: number) {
+    this.context = context;
+    this.lexerState = lexerState;
+    this.offset = offset;
+  }
+
+}

--- a/test/src/Test.ts
+++ b/test/src/Test.ts
@@ -86,6 +86,8 @@ export class Test {
         return PhpVersion.PHP7_3;
       case '7_4':
         return PhpVersion.PHP7_4;
+      case '8_0':
+        return PhpVersion.PHP8_0;
       default:
         return PhpVersion.Latest;
     }

--- a/test/src/language/syntax/SyntaxNodeTest.ts
+++ b/test/src/language/syntax/SyntaxNodeTest.ts
@@ -27,6 +27,7 @@ import {
   LocalVariableSyntaxNode
 } from '../../../../src/language/syntax/SyntaxNode.Generated';
 
+import { ErrorCode } from '../../../../src/diagnostics/ErrorCode.Generated';
 import { PhpSyntaxTree } from '../../../../src/parser/PhpSyntaxTree';
 import { SyntaxList } from '../../../../src/language/syntax/SyntaxList';
 import { TextSpan } from '../../../../src/text/TextSpan';
@@ -52,16 +53,24 @@ describe('SyntaxNode', function() {
   describe('#hasError', function() {
     it('no diagnostic', () => {
       let tree = PhpSyntaxTree.fromText('<?php $a;');
+      let diagnostics = Array.from(tree.getDiagnostics());
+      assert.strictEqual(diagnostics.length, 0);
       assert.strictEqual(tree.root.hasError, false);
     });
     it('error diagnostic', () => {
       // ERR_SemicolonExpected: ';' expected
       let tree = PhpSyntaxTree.fromText('<?php $a');
+      let diagnostics = Array.from(tree.getDiagnostics());
+      assert.strictEqual(diagnostics.length, 1);
+      assert.strictEqual(diagnostics[0].code, ErrorCode.ERR_SemicolonExpected);
       assert.strictEqual(tree.root.hasError, true);
     });
     it('warning diagnostic', () => {
-      // WRN_UnsetCast: The '(unset)' type cast is deprecated, use 'null' instead
-      let tree = PhpSyntaxTree.fromText('<?php (unset)$a;');
+      // WRN_EmptySwitchBlock: Empty switch block
+      let tree = PhpSyntaxTree.fromText('<?php switch ($a) {}');
+      let diagnostics = Array.from(tree.getDiagnostics());
+      assert.strictEqual(diagnostics.length, 1);
+      assert.strictEqual(diagnostics[0].code, ErrorCode.WRN_EmptySwitchBlock);
       assert.strictEqual(tree.root.hasError, false);
     });
   });

--- a/test/src/parser/PhpLexerTest.ts
+++ b/test/src/parser/PhpLexerTest.ts
@@ -372,6 +372,16 @@ describe('PhpLexer', function() {
         new LexerTestArgs('<?php ??=', 'coalesce equal', [TokenKind.CoalesceEqual]),
       ];
       Test.assertTokens(tests7_4, PhpVersion.PHP7_4);
+
+      let tests8_0 = [
+        new LexerTestArgs('<?php ?->', 'null-safe object operator', [TokenKind.NullSafeObjectOperator]),
+      ];
+      Test.assertTokens(tests8_0, PhpVersion.PHP8_0);
+
+      let regressionTests8_0 = [
+        new LexerTestArgs('<?php ?->', 'should not match null-safe object operator', [TokenKind.Question, TokenKind.ObjectOperator]),
+      ];
+      Test.assertTokens(regressionTests8_0, PhpVersion.PHP7_0, PhpVersion.PHP7_4);
     });
 
     describe('type casts', function() {

--- a/test/src/parser/PhpLexerTest.ts
+++ b/test/src/parser/PhpLexerTest.ts
@@ -373,6 +373,11 @@ describe('PhpLexer', function() {
       ];
       Test.assertTokens(tests7_4, PhpVersion.PHP7_4);
 
+      let regressionTests7_4 = [
+        new LexerTestArgs('<?php ??=', 'should not match coalesce equal', [TokenKind.Coalesce, TokenKind.Equal]),
+      ];
+      Test.assertTokens(regressionTests7_4, PhpVersion.PHP7_0, PhpVersion.PHP7_3);
+
       let tests8_0 = [
         new LexerTestArgs('<?php ?->', 'null-safe object operator', [TokenKind.NullSafeObjectOperator]),
       ];

--- a/test/src/parser/PhpLexerTest.ts
+++ b/test/src/parser/PhpLexerTest.ts
@@ -173,33 +173,6 @@ describe('PhpLexer', function() {
       Test.assertTokens(regressionTests7_4, PhpVersion.PHP7_0, PhpVersion.PHP7_3);
     });
 
-    describe('string literals', function() {
-      let tests = [
-        new LexerTestArgs('<?php \'a\'', 'single quote', [TokenKind.StringLiteral], ['\'a\'']),
-        new LexerTestArgs('<?php \'$a\'', 'single quote with variable', [TokenKind.StringLiteral], ['\'$a\'']),
-        new LexerTestArgs('<?php \'\\\\\'', 'single quote with escaped backslash', [TokenKind.StringLiteral], ['\'\\\\\'']),
-        new LexerTestArgs('<?php \'\\\'\'', 'single quote with escaped single quote', [TokenKind.StringLiteral], ['\'\\\'\'']),
-        new LexerTestArgs('<?php \'\\n\'', 'single quote with escaped line feed (invalid)', [TokenKind.StringLiteral], ['\'\\n\'']),
-
-        new LexerTestArgs('<?php "a"', 'double quote', [TokenKind.StringLiteral], ['"a"']),
-        new LexerTestArgs('<?php "\\""', 'double quote with escaped double quote', [TokenKind.StringLiteral], ['"\\""']),
-        new LexerTestArgs('<?php "\\n"', 'double quote with escaped line feed', [TokenKind.StringLiteral], ['"\\n"']),
-        new LexerTestArgs('<?php "\\$a"', 'double quote with escaped variable sigil', [TokenKind.StringLiteral], ['"\\$a"']),
-        new LexerTestArgs('<?php "$1.00"', 'double quote with text containing variable sigil', [TokenKind.StringLiteral], ['"$1.00"']),
-        new LexerTestArgs('<?php "\\u110000"', 'double quote with JSON-encoded unicode escape sequence', [TokenKind.StringLiteral], ['"\\u110000"']),
-      ];
-      Test.assertTokens(tests);
-
-      let diagnosticTests = [
-        new LexerDiagnosticTestArgs('<?php \'a', 'unterminated string literal', TokenKind.StringLiteral, ErrorCode.ERR_UnterminatedStringConstant),
-        new LexerDiagnosticTestArgs('<?php "\\u{"', 'double quote with unterminated unicode escape sequence', TokenKind.StringLiteral, ErrorCode.ERR_UnterminatedUnicodeEscapeSequence),
-        new LexerDiagnosticTestArgs('<?php "\\u{}"', 'double quote with empty unicode escape sequence', TokenKind.StringLiteral, ErrorCode.ERR_InvalidEscapeSequenceUnicode),
-        new LexerDiagnosticTestArgs('<?php "\\u{110000}"', 'double quote with unicode escape sequence overflow', TokenKind.StringLiteral, ErrorCode.ERR_UnicodeEscapeSequenceOverflow),
-        new LexerDiagnosticTestArgs('<?php "\\400"', 'double quote with octal escape sequence overflow', TokenKind.StringLiteral, ErrorCode.WRN_OctalEscapeSequenceOverflow),
-      ];
-      Test.assertTokenDiagnostics(diagnosticTests);
-    });
-
     describe('numbers', function() {
       let tests = [
         new LexerTestArgs('<?php 0xFF', 'hexadecimal number', [TokenKind.LNumber], ['0xFF']),
@@ -387,6 +360,33 @@ describe('PhpLexer', function() {
         new LexerTestArgs('<?php ?->', 'should not match null-safe object operator', [TokenKind.Question, TokenKind.ObjectOperator]),
       ];
       Test.assertTokens(regressionTests8_0, PhpVersion.PHP7_0, PhpVersion.PHP7_4);
+    });
+
+    describe('string literals', function() {
+      let tests = [
+        new LexerTestArgs('<?php \'a\'', 'single quote', [TokenKind.StringLiteral], ['\'a\'']),
+        new LexerTestArgs('<?php \'$a\'', 'single quote with variable', [TokenKind.StringLiteral], ['\'$a\'']),
+        new LexerTestArgs('<?php \'\\\\\'', 'single quote with escaped backslash', [TokenKind.StringLiteral], ['\'\\\\\'']),
+        new LexerTestArgs('<?php \'\\\'\'', 'single quote with escaped single quote', [TokenKind.StringLiteral], ['\'\\\'\'']),
+        new LexerTestArgs('<?php \'\\n\'', 'single quote with escaped line feed (invalid)', [TokenKind.StringLiteral], ['\'\\n\'']),
+
+        new LexerTestArgs('<?php "a"', 'double quote', [TokenKind.StringLiteral], ['"a"']),
+        new LexerTestArgs('<?php "\\""', 'double quote with escaped double quote', [TokenKind.StringLiteral], ['"\\""']),
+        new LexerTestArgs('<?php "\\n"', 'double quote with escaped line feed', [TokenKind.StringLiteral], ['"\\n"']),
+        new LexerTestArgs('<?php "\\$a"', 'double quote with escaped variable sigil', [TokenKind.StringLiteral], ['"\\$a"']),
+        new LexerTestArgs('<?php "$1.00"', 'double quote with text containing variable sigil', [TokenKind.StringLiteral], ['"$1.00"']),
+        new LexerTestArgs('<?php "\\u110000"', 'double quote with JSON-encoded unicode escape sequence', [TokenKind.StringLiteral], ['"\\u110000"']),
+      ];
+      Test.assertTokens(tests);
+
+      let diagnosticTests = [
+        new LexerDiagnosticTestArgs('<?php \'a', 'unterminated string literal', TokenKind.StringLiteral, ErrorCode.ERR_UnterminatedStringConstant),
+        new LexerDiagnosticTestArgs('<?php "\\u{"', 'double quote with unterminated unicode escape sequence', TokenKind.StringLiteral, ErrorCode.ERR_UnterminatedUnicodeEscapeSequence),
+        new LexerDiagnosticTestArgs('<?php "\\u{}"', 'double quote with empty unicode escape sequence', TokenKind.StringLiteral, ErrorCode.ERR_InvalidEscapeSequenceUnicode),
+        new LexerDiagnosticTestArgs('<?php "\\u{110000}"', 'double quote with unicode escape sequence overflow', TokenKind.StringLiteral, ErrorCode.ERR_UnicodeEscapeSequenceOverflow),
+        new LexerDiagnosticTestArgs('<?php "\\400"', 'double quote with octal escape sequence overflow', TokenKind.StringLiteral, ErrorCode.WRN_OctalEscapeSequenceOverflow),
+      ];
+      Test.assertTokenDiagnostics(diagnosticTests);
     });
 
     describe('type casts', function() {

--- a/test/src/parser/PhpLexerTest.ts
+++ b/test/src/parser/PhpLexerTest.ts
@@ -168,9 +168,19 @@ describe('PhpLexer', function() {
       Test.assertTokens(tests7_4, PhpVersion.PHP7_4);
 
       let regressionTests7_4 = [
-        new LexerTestArgs('<?php fn', 'fn', [TokenKind.Identifier]),
+        new LexerTestArgs('<?php fn', 'fn (identifier)', [TokenKind.Identifier]),
       ];
       Test.assertTokens(regressionTests7_4, PhpVersion.PHP7_0, PhpVersion.PHP7_3);
+
+      let tests8_0 = [
+        new LexerTestArgs('<?php match', 'match', [TokenKind.Match]),
+      ];
+      Test.assertTokens(tests8_0, PhpVersion.PHP8_0);
+
+      let regressionTests8_0 = [
+        new LexerTestArgs('<?php match', 'match (identifier)', [TokenKind.Identifier]),
+      ];
+      Test.assertTokens(regressionTests8_0, PhpVersion.PHP7_0, PhpVersion.PHP7_4);
     });
 
     describe('numbers', function() {

--- a/test/src/parser/PhpLexerTest.ts
+++ b/test/src/parser/PhpLexerTest.ts
@@ -385,9 +385,7 @@ describe('PhpLexer', function() {
         new LexerTestArgs('<?php (integer)', 'to integer (integer)', [TokenKind.IntegerCast]),
         new LexerTestArgs('<?php (float)', 'to float (float)', [TokenKind.FloatCast]),
         new LexerTestArgs('<?php (object)', 'to object (object)', [TokenKind.ObjectCast]),
-        new LexerTestArgs('<?php (real)', 'to float (real)', [TokenKind.RealCast]),
         new LexerTestArgs('<?php (string)', 'to string (string)', [TokenKind.StringCast]),
-        new LexerTestArgs('<?php (unset)', 'type unset', [TokenKind.UnsetCast]),
         new LexerTestArgs('<?php (  int)', 'should match with leading spaces', [TokenKind.IntCast]),
         new LexerTestArgs('<?php (int  )', 'should match with trailing spaces', [TokenKind.IntCast]),
         new LexerTestArgs('<?php (\tint)', 'should match with leading tab', [TokenKind.IntCast]),
@@ -395,6 +393,18 @@ describe('PhpLexer', function() {
         new LexerTestArgs('<?php (\nint)', 'should not match with new lines', [TokenKind.OpenParen, TokenKind.Identifier, TokenKind.CloseParen]),
       ];
       Test.assertTokens(tests);
+
+      let tests8_0 = [
+        new LexerTestArgs('<?php (real)', 'should not match real type cast', [TokenKind.OpenParen, TokenKind.Identifier, TokenKind.CloseParen]),
+        new LexerTestArgs('<?php (unset)', 'should not match unset type cast', [TokenKind.OpenParen, TokenKind.Unset, TokenKind.CloseParen]),
+      ];
+      Test.assertTokens(tests8_0, PhpVersion.PHP8_0);
+
+      let regressionTests8_0 = [
+        new LexerTestArgs('<?php (real)', 'to float (real)', [TokenKind.RealCast]),
+        new LexerTestArgs('<?php (unset)', 'to null (unset)', [TokenKind.UnsetCast]),
+      ];
+      Test.assertTokens(regressionTests8_0, PhpVersion.PHP7_0, PhpVersion.PHP7_4);
     });
 
     describe('variables', function() {
@@ -406,13 +416,11 @@ describe('PhpLexer', function() {
         new LexerTestArgs('<?php $1', 'should not start with a number', [TokenKind.Dollar, TokenKind.LNumber], ['$', '1']),
       ];
       Test.assertTokens(tests);
-    });
 
-    describe('variables (7.0)', function() {
-      let tests = [
+      let regressionTests7_1 = [
         new LexerTestArgs('<?php $\x7F', 'variable (lowest extended character)', [TokenKind.Variable], ['$\x7F']),
       ];
-      Test.assertTokens(tests, PhpVersion.PHP7_0, PhpVersion.PHP7_0);
+      Test.assertTokens(regressionTests7_1, PhpVersion.PHP7_0, PhpVersion.PHP7_0);
     });
 
     describe('unexpected characters', function() {

--- a/test/src/parser/PhpLexerTest_Interpolations.ts
+++ b/test/src/parser/PhpLexerTest_Interpolations.ts
@@ -165,6 +165,50 @@ describe('PhpLexer', function() {
       assertRescannedTokens(lexerTests, TokenKind.StringTemplate);
     });
 
+    describe('looking for property (null-safe operator)', function() {
+      let lexerTests = [
+        new LexerTestArgs('"$a?->b"', 'null-safe object operator with identifier',
+          [TokenKind.DoubleQuote, TokenKind.Variable, TokenKind.NullSafeObjectOperator, TokenKind.Identifier, TokenKind.DoubleQuote],
+          ['"', '$a', '?->', 'b', '"']
+        ),
+        new LexerTestArgs('" $a?->b"', 'null-safe object operator with identifier in string with leading text',
+          [TokenKind.DoubleQuote, TokenKind.StringTemplateLiteral, TokenKind.Variable, TokenKind.NullSafeObjectOperator, TokenKind.Identifier, TokenKind.DoubleQuote],
+          ['"', ' ', '$a', '?->', 'b', '"']
+        ),
+
+        new LexerTestArgs('"$a?->"', 'should not start if identifier is missing',
+          [TokenKind.DoubleQuote, TokenKind.Variable, TokenKind.StringTemplateLiteral, TokenKind.DoubleQuote],
+          ['"', '$a', '?->', '"']
+        ),
+        new LexerTestArgs('"$a ?->b"', 'should not start if whitespace is before null-safe object operator',
+          [TokenKind.DoubleQuote, TokenKind.Variable, TokenKind.StringTemplateLiteral, TokenKind.DoubleQuote],
+          ['"', '$a', ' ?->b', '"']
+        ),
+        new LexerTestArgs('"$a\n\t?->b"', 'should not start if whitespace is before null-safe object operator (multiple)',
+          [TokenKind.DoubleQuote, TokenKind.Variable, TokenKind.StringTemplateLiteral, TokenKind.DoubleQuote],
+          ['"', '$a', '\n\t?->b', '"']
+        ),
+        new LexerTestArgs('"$a?-> b"', 'should not start if whitespace is after null-safe object operator',
+          [TokenKind.DoubleQuote, TokenKind.Variable, TokenKind.StringTemplateLiteral, TokenKind.DoubleQuote],
+          ['"', '$a', '?-> b', '"']
+        ),
+        new LexerTestArgs('"$a?->\n\tb"', 'should not start if whitespace is after null-safe object operator (multiple)',
+          [TokenKind.DoubleQuote, TokenKind.Variable, TokenKind.StringTemplateLiteral, TokenKind.DoubleQuote],
+          ['"', '$a', '?->\n\tb', '"']
+        ),
+
+        new LexerTestArgs('"$a?->b', 'should end at EOF',
+          [TokenKind.DoubleQuote, TokenKind.Variable, TokenKind.NullSafeObjectOperator, TokenKind.Identifier],
+          ['"', '$a', '?->', 'b']
+        ),
+        new LexerTestArgs('"$a?->b?->c"', 'should end after first property',
+          [TokenKind.DoubleQuote, TokenKind.Variable, TokenKind.NullSafeObjectOperator, TokenKind.Identifier, TokenKind.StringTemplateLiteral, TokenKind.DoubleQuote],
+          ['"', '$a', '?->', 'b', '?->c', '"']
+        ),
+      ];
+      assertRescannedTokens(lexerTests, TokenKind.StringTemplate, PhpVersion.PHP8_0);
+    });
+
     describe('looking for variable name', function() {
       let lexerTests = [
         new LexerTestArgs('"${a}"', 'indirect variable name',

--- a/test/src/parser/PhpParserTest_ClassDeclaration.ts
+++ b/test/src/parser/PhpParserTest_ClassDeclaration.ts
@@ -55,7 +55,7 @@ import { TokenKind } from '../../../src/language/TokenKind';
 
 function assertClassConstantDeclaration(statements: ISyntaxNode[]): ClassConstantDeclarationSyntaxNode {
   let classNode = <ClassDeclarationSyntaxNode>statements[0];
-  assert.strictEqual(classNode instanceof ClassDeclarationSyntaxNode, true, 'is a ClassDeclarationSyntaxNode');
+  assert.strictEqual(classNode instanceof ClassDeclarationSyntaxNode, true, 'ClassDeclarationSyntaxNode');
   let members = classNode.members ? classNode.members.childNodes() : [];
   assert.strictEqual(members.length, 1);
   let classConstant = <ClassConstantDeclarationSyntaxNode>members[0];
@@ -65,7 +65,7 @@ function assertClassConstantDeclaration(statements: ISyntaxNode[]): ClassConstan
 
 function assertMethodDeclaration(statements: ISyntaxNode[]): MethodDeclarationSyntaxNode {
   let classNode = <ClassDeclarationSyntaxNode>statements[0];
-  assert.strictEqual(classNode instanceof ClassDeclarationSyntaxNode, true, 'is a ClassDeclarationSyntaxNode');
+  assert.strictEqual(classNode instanceof ClassDeclarationSyntaxNode, true, 'ClassDeclarationSyntaxNode');
   let members = classNode.members ? classNode.members.childNodes() : [];
   assert.strictEqual(members.length, 1);
   let method = <MethodDeclarationSyntaxNode>members[0];
@@ -112,7 +112,7 @@ function assertMethodParameter(node: ISyntaxNode, hasModifiers: boolean, hasType
 
 function assertPropertyDeclaration(statements: ISyntaxNode[]): PropertyDeclarationSyntaxNode {
   let classNode = <ClassDeclarationSyntaxNode>statements[0];
-  assert.strictEqual(classNode instanceof ClassDeclarationSyntaxNode, true, 'is a ClassDeclarationSyntaxNode');
+  assert.strictEqual(classNode instanceof ClassDeclarationSyntaxNode, true, 'ClassDeclarationSyntaxNode');
   let members = classNode.members ? classNode.members.childNodes() : [];
   assert.strictEqual(members.length, 1);
   let property = <PropertyDeclarationSyntaxNode>members[0];
@@ -122,7 +122,7 @@ function assertPropertyDeclaration(statements: ISyntaxNode[]): PropertyDeclarati
 
 function assertTraitUse(statements: ISyntaxNode[]): TraitUseSyntaxNode {
   let classNode = <ClassDeclarationSyntaxNode>statements[0];
-  assert.strictEqual(classNode instanceof ClassDeclarationSyntaxNode, true, 'is a ClassDeclarationSyntaxNode');
+  assert.strictEqual(classNode instanceof ClassDeclarationSyntaxNode, true, 'ClassDeclarationSyntaxNode');
   let members = classNode.members ? classNode.members.childNodes() : [];
   assert.strictEqual(members.length, 1);
   let traitUse = <TraitUseSyntaxNode>members[0];
@@ -132,7 +132,7 @@ function assertTraitUse(statements: ISyntaxNode[]): TraitUseSyntaxNode {
 
 function assertTraitUseGroup(statements: ISyntaxNode[]): TraitUseGroupSyntaxNode {
   let classNode = <ClassDeclarationSyntaxNode>statements[0];
-  assert.strictEqual(classNode instanceof ClassDeclarationSyntaxNode, true, 'is a ClassDeclarationSyntaxNode');
+  assert.strictEqual(classNode instanceof ClassDeclarationSyntaxNode, true, 'ClassDeclarationSyntaxNode');
   let members = classNode.members ? classNode.members.childNodes() : [];
   assert.strictEqual(members.length, 1);
   let traitUseGroup = <TraitUseGroupSyntaxNode>members[0];
@@ -146,7 +146,7 @@ describe('PhpParser', function() {
     let syntaxTests = [
       new ParserTestArgs('class A {}', 'should parse a class declaration', (statements, text) => {
         let classNode = <ClassDeclarationSyntaxNode>statements[0];
-        assert.strictEqual(classNode instanceof ClassDeclarationSyntaxNode, true, 'is a ClassDeclarationSyntaxNode');
+        assert.strictEqual(classNode instanceof ClassDeclarationSyntaxNode, true, 'ClassDeclarationSyntaxNode');
         Test.assertSyntaxToken(classNode.identifier, text, TokenKind.Identifier, 'A');
         assert.strictEqual(classNode.baseType, null);
         assert.strictEqual(classNode.interfaces, null);
@@ -157,14 +157,14 @@ describe('PhpParser', function() {
       // @todo Should parse, but also cause an error during analysis?
       // new ParserTestArgs('class int {}', 'should parse a class with a reserved name', (statements) => {
       //   let classNode = <ClassDeclarationSyntaxNode>statements[0];
-      //   assert.strictEqual(classNode instanceof ClassDeclarationSyntaxNode, true, 'is a ClassDeclarationSyntaxNode');
+      //   assert.strictEqual(classNode instanceof ClassDeclarationSyntaxNode, true, 'ClassDeclarationSyntaxNode');
       //   assert.strictEqual(classNode.baseType, null);
       //   assert.strictEqual(classNode.interfaces, null);
       //   assert.strictEqual(classNode.members, null);
       // }),
       new ParserTestArgs('{ class A {} }', 'should parse a class declaration in statement block', (statements) => {
         let block = <StatementBlockSyntaxNode>statements[0];
-        assert.strictEqual(block instanceof StatementBlockSyntaxNode, true, 'is a StatementBlockSyntaxNode');
+        assert.strictEqual(block instanceof StatementBlockSyntaxNode, true, 'StatementBlockSyntaxNode');
         let innerStatements = block.childNodes();
         assert.strictEqual(innerStatements.length, 1);
         assert.strictEqual(innerStatements[0] instanceof ClassDeclarationSyntaxNode, true);
@@ -191,7 +191,7 @@ describe('PhpParser', function() {
     let syntaxTests = [
       new ParserTestArgs('abstract class A {}', 'should parse an abstract class declaration', (statements, text) => {
         let classNode = <ClassDeclarationSyntaxNode>statements[0];
-        assert.strictEqual(classNode instanceof ClassDeclarationSyntaxNode, true, 'is a ClassDeclarationSyntaxNode');
+        assert.strictEqual(classNode instanceof ClassDeclarationSyntaxNode, true, 'ClassDeclarationSyntaxNode');
         let modifiers = classNode.modifiers ? classNode.modifiers.childTokens() : [];
         assert.strictEqual(modifiers.length, 1);
         Test.assertSyntaxToken(classNode.identifier, text, TokenKind.Identifier, 'A');
@@ -201,7 +201,7 @@ describe('PhpParser', function() {
       }),
       new ParserTestArgs('final class A {}', 'should parse a final class declaration', (statements, text) => {
         let classNode = <ClassDeclarationSyntaxNode>statements[0];
-        assert.strictEqual(classNode instanceof ClassDeclarationSyntaxNode, true, 'is a ClassDeclarationSyntaxNode');
+        assert.strictEqual(classNode instanceof ClassDeclarationSyntaxNode, true, 'ClassDeclarationSyntaxNode');
         let modifiers = classNode.modifiers ? classNode.modifiers.childTokens() : [];
         assert.strictEqual(modifiers.length, 1);
         Test.assertSyntaxToken(classNode.identifier, text, TokenKind.Identifier, 'A');
@@ -237,21 +237,21 @@ describe('PhpParser', function() {
     let syntaxTests = [
       new ParserTestArgs('class A extends B {}', 'should parse a class declaration with a base type', (statements) => {
         let classNode = <ClassDeclarationSyntaxNode>statements[0];
-        assert.strictEqual(classNode instanceof ClassDeclarationSyntaxNode, true, 'is a ClassDeclarationSyntaxNode');
+        assert.strictEqual(classNode instanceof ClassDeclarationSyntaxNode, true, 'ClassDeclarationSyntaxNode');
         assert.strictEqual(classNode.baseType instanceof PartiallyQualifiedNameSyntaxNode, true);
         assert.strictEqual(classNode.interfaces, null);
         assert.strictEqual(classNode.members, null);
       }),
       new ParserTestArgs('class A extends \\B {}', 'should parse a class declaration with fully qualified base type', (statements) => {
         let classNode = <ClassDeclarationSyntaxNode>statements[0];
-        assert.strictEqual(classNode instanceof ClassDeclarationSyntaxNode, true, 'is a ClassDeclarationSyntaxNode');
+        assert.strictEqual(classNode instanceof ClassDeclarationSyntaxNode, true, 'ClassDeclarationSyntaxNode');
         assert.strictEqual(classNode.baseType instanceof FullyQualifiedNameSyntaxNode, true);
         assert.strictEqual(classNode.interfaces, null);
         assert.strictEqual(classNode.members, null);
       }),
       new ParserTestArgs('class A extends namespace\\B {}', 'should parse a class declaration with relative base type', (statements) => {
         let classNode = <ClassDeclarationSyntaxNode>statements[0];
-        assert.strictEqual(classNode instanceof ClassDeclarationSyntaxNode, true, 'is a ClassDeclarationSyntaxNode');
+        assert.strictEqual(classNode instanceof ClassDeclarationSyntaxNode, true, 'ClassDeclarationSyntaxNode');
         assert.strictEqual(classNode.baseType instanceof RelativeNameSyntaxNode, true);
         assert.strictEqual(classNode.interfaces, null);
         assert.strictEqual(classNode.members, null);
@@ -276,7 +276,7 @@ describe('PhpParser', function() {
     let syntaxTests = [
       new ParserTestArgs('class A implements B {}', 'should parse a class declaration with single interface type', (statements) => {
         let classNode = <ClassDeclarationSyntaxNode>statements[0];
-        assert.strictEqual(classNode instanceof ClassDeclarationSyntaxNode, true, 'is a ClassDeclarationSyntaxNode');
+        assert.strictEqual(classNode instanceof ClassDeclarationSyntaxNode, true, 'ClassDeclarationSyntaxNode');
         assert.strictEqual(classNode.baseType, null);
         let interfaces = classNode.interfaces ? classNode.interfaces.childNodes() : [];
         assert.strictEqual(interfaces.length, 1);
@@ -285,7 +285,7 @@ describe('PhpParser', function() {
       }),
       new ParserTestArgs('class A implements B, C {}', 'should parse a class declaration with multiple interface types', (statements) => {
         let classNode = <ClassDeclarationSyntaxNode>statements[0];
-        assert.strictEqual(classNode instanceof ClassDeclarationSyntaxNode, true, 'is a ClassDeclarationSyntaxNode');
+        assert.strictEqual(classNode instanceof ClassDeclarationSyntaxNode, true, 'ClassDeclarationSyntaxNode');
         assert.strictEqual(classNode.baseType, null);
         let interfaces = classNode.interfaces ? classNode.interfaces.childNodes() : [];
         assert.strictEqual(interfaces.length, 2);
@@ -295,7 +295,7 @@ describe('PhpParser', function() {
       }),
       new ParserTestArgs('class A implements \\B {}', 'should parse a class declaration with fully qualified interface type', (statements) => {
         let classNode = <ClassDeclarationSyntaxNode>statements[0];
-        assert.strictEqual(classNode instanceof ClassDeclarationSyntaxNode, true, 'is a ClassDeclarationSyntaxNode');
+        assert.strictEqual(classNode instanceof ClassDeclarationSyntaxNode, true, 'ClassDeclarationSyntaxNode');
         assert.strictEqual(classNode.baseType, null);
         let interfaces = classNode.interfaces ? classNode.interfaces.childNodes() : [];
         assert.strictEqual(interfaces.length, 1);
@@ -304,7 +304,7 @@ describe('PhpParser', function() {
       }),
       new ParserTestArgs('class A implements namespace\\B {}', 'should parse a class declaration with relative interface type', (statements) => {
         let classNode = <ClassDeclarationSyntaxNode>statements[0];
-        assert.strictEqual(classNode instanceof ClassDeclarationSyntaxNode, true, 'is a ClassDeclarationSyntaxNode');
+        assert.strictEqual(classNode instanceof ClassDeclarationSyntaxNode, true, 'ClassDeclarationSyntaxNode');
         assert.strictEqual(classNode.baseType, null);
         let interfaces = classNode.interfaces ? classNode.interfaces.childNodes() : [];
         assert.strictEqual(interfaces.length, 1);

--- a/test/src/parser/PhpParserTest_ClassDeclaration.ts
+++ b/test/src/parser/PhpParserTest_ClassDeclaration.ts
@@ -536,6 +536,13 @@ describe('PhpParser', function() {
       Test.assertSyntaxNodes(syntaxTests7_1, PhpVersion.PHP7_1);
 
       let syntaxTests8_0 = [
+        new ParserTestArgs('class A { function b(): static {} }', 'should parse a method declaration with static return type', (statements, text) => {
+          let method = assertMethodDeclaration(statements);
+          assert.strictEqual(method.modifiers, null);
+          assert.strictEqual(method.ampersand, null);
+          Test.assertSyntaxToken(method.identifierOrKeyword, text, TokenKind.Identifier, 'b');
+          assert.strictEqual(method.returnType instanceof PredefinedTypeSyntaxNode, true, 'PredefinedTypeSyntaxNode');
+        }),
         new ParserTestArgs('class A { function b(): array | C {} }', 'should parse a method declaration with type union', (statements, text) => {
           let method = assertMethodDeclaration(statements);
           assert.strictEqual(method.modifiers, null);
@@ -580,6 +587,7 @@ describe('PhpParser', function() {
       let diagnosticRegressionTests8_0 = [
         new DiagnosticTestArgs('class A { function b(): C', 'missing open brace', [ErrorCode.ERR_OpenBraceExpected], [25]),
         new DiagnosticTestArgs('class A { function b(): C | D {} }', 'should not parse a type union', [ErrorCode.ERR_FeatureUnionTypes], [24]),
+        new DiagnosticTestArgs('class A { function b(): static {} }', 'should not parse a static return type', [ErrorCode.ERR_FeatureStaticReturnType], [24]),
         new DiagnosticTestArgs('class A { abstract function b(): C }', 'missing semicolon', [ErrorCode.ERR_SemicolonExpected], [34]),
       ];
       Test.assertDiagnostics(diagnosticRegressionTests8_0, PhpVersion.PHP7_0, PhpVersion.PHP7_4);

--- a/test/src/parser/PhpParserTest_ClassDeclaration.ts
+++ b/test/src/parser/PhpParserTest_ClassDeclaration.ts
@@ -59,7 +59,7 @@ function assertClassConstantDeclaration(statements: ISyntaxNode[]): ClassConstan
   let members = classNode.members ? classNode.members.childNodes() : [];
   assert.strictEqual(members.length, 1);
   let classConstant = <ClassConstantDeclarationSyntaxNode>members[0];
-  assert.strictEqual(classConstant instanceof ClassConstantDeclarationSyntaxNode, true);
+  assert.strictEqual(classConstant instanceof ClassConstantDeclarationSyntaxNode, true, 'ClassConstantDeclarationSyntaxNode');
   return classConstant;
 }
 
@@ -69,7 +69,7 @@ function assertMethodDeclaration(statements: ISyntaxNode[]): MethodDeclarationSy
   let members = classNode.members ? classNode.members.childNodes() : [];
   assert.strictEqual(members.length, 1);
   let method = <MethodDeclarationSyntaxNode>members[0];
-  assert.strictEqual(method instanceof MethodDeclarationSyntaxNode, true);
+  assert.strictEqual(method instanceof MethodDeclarationSyntaxNode, true, 'MethodDeclarationSyntaxNode');
   return method;
 }
 
@@ -116,8 +116,19 @@ function assertPropertyDeclaration(statements: ISyntaxNode[]): PropertyDeclarati
   let members = classNode.members ? classNode.members.childNodes() : [];
   assert.strictEqual(members.length, 1);
   let property = <PropertyDeclarationSyntaxNode>members[0];
-  assert.strictEqual(property instanceof PropertyDeclarationSyntaxNode, true);
+  assert.strictEqual(property instanceof PropertyDeclarationSyntaxNode, true, 'PropertyDeclarationSyntaxNode');
   return property;
+}
+
+function assertPropertyElements(node: PropertyDeclarationSyntaxNode, text: string, expected: string[]): void {
+  let elements = node.properties.childNodes();
+  assert.strictEqual(elements.length, expected.length);
+  for (let i = 0; i < elements.length; i++) {
+    let element = <PropertyElementSyntaxNode>elements[i];
+    assert.strictEqual(element instanceof PropertyElementSyntaxNode, true, 'PropertyElementSyntaxNode');
+    Test.assertSyntaxToken(element.variable, text, TokenKind.Variable, expected[i]);
+    assert.strictEqual(element.expression, null);
+  }
 }
 
 function assertTraitUse(statements: ISyntaxNode[]): TraitUseSyntaxNode {
@@ -126,7 +137,7 @@ function assertTraitUse(statements: ISyntaxNode[]): TraitUseSyntaxNode {
   let members = classNode.members ? classNode.members.childNodes() : [];
   assert.strictEqual(members.length, 1);
   let traitUse = <TraitUseSyntaxNode>members[0];
-  assert.strictEqual(traitUse instanceof TraitUseSyntaxNode, true);
+  assert.strictEqual(traitUse instanceof TraitUseSyntaxNode, true, 'TraitUseSyntaxNode');
   return traitUse;
 }
 
@@ -136,7 +147,7 @@ function assertTraitUseGroup(statements: ISyntaxNode[]): TraitUseGroupSyntaxNode
   let members = classNode.members ? classNode.members.childNodes() : [];
   assert.strictEqual(members.length, 1);
   let traitUseGroup = <TraitUseGroupSyntaxNode>members[0];
-  assert.strictEqual(traitUseGroup instanceof TraitUseGroupSyntaxNode, true);
+  assert.strictEqual(traitUseGroup instanceof TraitUseGroupSyntaxNode, true, 'TraitUseGroupSyntaxNode');
   return traitUseGroup;
 }
 
@@ -735,12 +746,7 @@ describe('PhpParser', function() {
           assert.strictEqual(modifiers.length, 1);
           Test.assertSyntaxToken(modifiers[0], text, TokenKind.Public, 'public');
           assert.strictEqual(declNode.type, null);
-          let elements = declNode.properties ? declNode.properties.childNodes() : [];
-          assert.strictEqual(elements.length, 1);
-          let propertyNode = <PropertyElementSyntaxNode>elements[0];
-          assert.strictEqual(propertyNode instanceof PropertyElementSyntaxNode, true);
-          Test.assertSyntaxToken(propertyNode.variable, text, TokenKind.Variable, '$b');
-          assert.strictEqual(propertyNode.expression, null);
+          assertPropertyElements(declNode, text, ['$b']);
         }),
         new ParserTestArgs('class A { var $b; }', 'should parse a property declaration (var)', (statements, text) => {
           let declNode = assertPropertyDeclaration(statements);
@@ -748,12 +754,7 @@ describe('PhpParser', function() {
           assert.strictEqual(modifiers.length, 1);
           Test.assertSyntaxToken(modifiers[0], text, TokenKind.Var, 'var');
           assert.strictEqual(declNode.type, null);
-          let elements = declNode.properties ? declNode.properties.childNodes() : [];
-          assert.strictEqual(elements.length, 1);
-          let propertyNode = <PropertyElementSyntaxNode>elements[0];
-          assert.strictEqual(propertyNode instanceof PropertyElementSyntaxNode, true);
-          Test.assertSyntaxToken(propertyNode.variable, text, TokenKind.Variable, '$b');
-          assert.strictEqual(propertyNode.expression, null);
+          assertPropertyElements(declNode, text, ['$b']);
         }),
         new ParserTestArgs('class A { public $b = 1; }', 'should parse a property declaration with assignment', (statements, text) => {
           let declNode = assertPropertyDeclaration(statements);
@@ -774,16 +775,7 @@ describe('PhpParser', function() {
           assert.strictEqual(modifiers.length, 1);
           Test.assertSyntaxToken(modifiers[0], text, TokenKind.Public, 'public');
           assert.strictEqual(declNode.type, null);
-          let elements = declNode.properties ? declNode.properties.childNodes() : [];
-          assert.strictEqual(elements.length, 2);
-          let firstProperty = <PropertyElementSyntaxNode>elements[0];
-          assert.strictEqual(firstProperty instanceof PropertyElementSyntaxNode, true);
-          Test.assertSyntaxToken(firstProperty.variable, text, TokenKind.Variable, '$b');
-          assert.strictEqual(firstProperty.expression, null);
-          let secondProperty = <PropertyElementSyntaxNode>elements[1];
-          assert.strictEqual(secondProperty instanceof PropertyElementSyntaxNode, true);
-          Test.assertSyntaxToken(secondProperty.variable, text, TokenKind.Variable, '$c');
-          assert.strictEqual(secondProperty.expression, null);
+          assertPropertyElements(declNode, text, ['$b', '$c']);
         }),
         new ParserTestArgs('class A { protected $b; }', 'should parse a protected property declaration', (statements, text) => {
           let declNode = assertPropertyDeclaration(statements);
@@ -791,12 +783,7 @@ describe('PhpParser', function() {
           assert.strictEqual(modifiers.length, 1);
           Test.assertSyntaxToken(modifiers[0], text, TokenKind.Protected, 'protected');
           assert.strictEqual(declNode.type, null);
-          let elements = declNode.properties ? declNode.properties.childNodes() : [];
-          assert.strictEqual(elements.length, 1);
-          let propertyNode = <PropertyElementSyntaxNode>elements[0];
-          assert.strictEqual(propertyNode instanceof PropertyElementSyntaxNode, true);
-          Test.assertSyntaxToken(propertyNode.variable, text, TokenKind.Variable, '$b');
-          assert.strictEqual(propertyNode.expression, null);
+          assertPropertyElements(declNode, text, ['$b']);
         }),
         new ParserTestArgs('class A { private $b; }', 'should parse a private property declaration', (statements, text) => {
           let declNode = assertPropertyDeclaration(statements);
@@ -804,12 +791,7 @@ describe('PhpParser', function() {
           assert.strictEqual(modifiers.length, 1);
           Test.assertSyntaxToken(modifiers[0], text, TokenKind.Private, 'private');
           assert.strictEqual(declNode.type, null);
-          let elements = declNode.properties ? declNode.properties.childNodes() : [];
-          assert.strictEqual(elements.length, 1);
-          let propertyNode = <PropertyElementSyntaxNode>elements[0];
-          assert.strictEqual(propertyNode instanceof PropertyElementSyntaxNode, true);
-          Test.assertSyntaxToken(propertyNode.variable, text, TokenKind.Variable, '$b');
-          assert.strictEqual(propertyNode.expression, null);
+          assertPropertyElements(declNode, text, ['$b']);
         }),
         new ParserTestArgs('class A { static $b; }', 'should parse a static property declaration', (statements, text) => {
           let declNode = assertPropertyDeclaration(statements);
@@ -817,12 +799,7 @@ describe('PhpParser', function() {
           assert.strictEqual(modifiers.length, 1);
           Test.assertSyntaxToken(modifiers[0], text, TokenKind.Static, 'static');
           assert.strictEqual(declNode.type, null);
-          let elements = declNode.properties ? declNode.properties.childNodes() : [];
-          assert.strictEqual(elements.length, 1);
-          let propertyNode = <PropertyElementSyntaxNode>elements[0];
-          assert.strictEqual(propertyNode instanceof PropertyElementSyntaxNode, true);
-          Test.assertSyntaxToken(propertyNode.variable, text, TokenKind.Variable, '$b');
-          assert.strictEqual(propertyNode.expression, null);
+          assertPropertyElements(declNode, text, ['$b']);
         }),
         new ParserTestArgs('class A { public static $b; }', 'should parse a static property declaration with visibility modifier (before)', (statements, text) => {
           let declNode = assertPropertyDeclaration(statements);
@@ -831,12 +808,7 @@ describe('PhpParser', function() {
           Test.assertSyntaxToken(modifiers[0], text, TokenKind.Public, 'public');
           Test.assertSyntaxToken(modifiers[1], text, TokenKind.Static, 'static');
           assert.strictEqual(declNode.type, null);
-          let elements = declNode.properties ? declNode.properties.childNodes() : [];
-          assert.strictEqual(elements.length, 1);
-          let propertyNode = <PropertyElementSyntaxNode>elements[0];
-          assert.strictEqual(propertyNode instanceof PropertyElementSyntaxNode, true);
-          Test.assertSyntaxToken(propertyNode.variable, text, TokenKind.Variable, '$b');
-          assert.strictEqual(propertyNode.expression, null);
+          assertPropertyElements(declNode, text, ['$b']);
         }),
         new ParserTestArgs('class A { static public $b; }', 'should parse a static property declaration with visibility modifier (after)', (statements, text) => {
           let declNode = assertPropertyDeclaration(statements);
@@ -845,12 +817,7 @@ describe('PhpParser', function() {
           Test.assertSyntaxToken(modifiers[0], text, TokenKind.Static, 'static');
           Test.assertSyntaxToken(modifiers[1], text, TokenKind.Public, 'public');
           assert.strictEqual(declNode.type, null);
-          let elements = declNode.properties ? declNode.properties.childNodes() : [];
-          assert.strictEqual(elements.length, 1);
-          let propertyNode = <PropertyElementSyntaxNode>elements[0];
-          assert.strictEqual(propertyNode instanceof PropertyElementSyntaxNode, true);
-          Test.assertSyntaxToken(propertyNode.variable, text, TokenKind.Variable, '$b');
-          assert.strictEqual(propertyNode.expression, null);
+          assertPropertyElements(declNode, text, ['$b']);
         }),
       ];
       Test.assertSyntaxNodes(syntaxTests);
@@ -861,84 +828,54 @@ describe('PhpParser', function() {
           let modifiers = declNode.modifiers ? declNode.modifiers.childTokens() : [];
           assert.strictEqual(modifiers.length, 1);
           Test.assertSyntaxToken(modifiers[0], text, TokenKind.Public, 'public');
-          assert.notStrictEqual(declNode.type, null);
-          assert.strictEqual(declNode.type ? declNode.type.question : false, null);
-          let elements = declNode.properties ? declNode.properties.childNodes() : [];
-          assert.strictEqual(elements.length, 1);
-          let propertyNode = <PropertyElementSyntaxNode>elements[0];
-          assert.strictEqual(propertyNode instanceof PropertyElementSyntaxNode, true);
-          Test.assertSyntaxToken(propertyNode.variable, text, TokenKind.Variable, '$c');
-          assert.strictEqual(propertyNode.expression, null);
+          assert.strictEqual(declNode.type instanceof NamedTypeSyntaxNode, true, 'NamedTypeSyntaxNode');
+          assert.strictEqual((<NamedTypeSyntaxNode>declNode.type).question, null);
+          assertPropertyElements(declNode, text, ['$c']);
         }),
         new ParserTestArgs('class A { var B $c; }', 'should parse a typed property declaration (var)', (statements, text) => {
           let declNode = assertPropertyDeclaration(statements);
           let modifiers = declNode.modifiers ? declNode.modifiers.childTokens() : [];
           assert.strictEqual(modifiers.length, 1);
           Test.assertSyntaxToken(modifiers[0], text, TokenKind.Var, 'var');
-          assert.notStrictEqual(declNode.type, null);
-          assert.strictEqual(declNode.type ? declNode.type.question : false, null);
-          let elements = declNode.properties ? declNode.properties.childNodes() : [];
-          assert.strictEqual(elements.length, 1);
-          let propertyNode = <PropertyElementSyntaxNode>elements[0];
-          assert.strictEqual(propertyNode instanceof PropertyElementSyntaxNode, true);
-          Test.assertSyntaxToken(propertyNode.variable, text, TokenKind.Variable, '$c');
-          assert.strictEqual(propertyNode.expression, null);
+          assert.strictEqual(declNode.type instanceof NamedTypeSyntaxNode, true, 'NamedTypeSyntaxNode');
+          assert.strictEqual((<NamedTypeSyntaxNode>declNode.type).question, null);
+          assertPropertyElements(declNode, text, ['$c']);
         }),
         new ParserTestArgs('class A { public \\B $c; }', 'should parse a typed property declaration with fully qualified name', (statements, text) => {
           let declNode = assertPropertyDeclaration(statements);
           let modifiers = declNode.modifiers ? declNode.modifiers.childTokens() : [];
           assert.strictEqual(modifiers.length, 1);
           Test.assertSyntaxToken(modifiers[0], text, TokenKind.Public, 'public');
-          assert.notStrictEqual(declNode.type, null);
-          assert.strictEqual(declNode.type ? declNode.type.question : false, null);
-          let elements = declNode.properties ? declNode.properties.childNodes() : [];
-          assert.strictEqual(elements.length, 1);
-          let propertyNode = <PropertyElementSyntaxNode>elements[0];
-          assert.strictEqual(propertyNode instanceof PropertyElementSyntaxNode, true);
-          Test.assertSyntaxToken(propertyNode.variable, text, TokenKind.Variable, '$c');
-          assert.strictEqual(propertyNode.expression, null);
+          assert.strictEqual(declNode.type instanceof NamedTypeSyntaxNode, true, 'NamedTypeSyntaxNode');
+          assert.strictEqual((<NamedTypeSyntaxNode>declNode.type).question, null);
+          assertPropertyElements(declNode, text, ['$c']);
         }),
         new ParserTestArgs('class A { public namespace\\B $c; }', 'should parse a typed property declaration with relative name', (statements, text) => {
           let declNode = assertPropertyDeclaration(statements);
           let modifiers = declNode.modifiers ? declNode.modifiers.childTokens() : [];
           assert.strictEqual(modifiers.length, 1);
           Test.assertSyntaxToken(modifiers[0], text, TokenKind.Public, 'public');
-          assert.notStrictEqual(declNode.type, null);
-          assert.strictEqual(declNode.type ? declNode.type.question : false, null);
-          let elements = declNode.properties ? declNode.properties.childNodes() : [];
-          assert.strictEqual(elements.length, 1);
-          let propertyNode = <PropertyElementSyntaxNode>elements[0];
-          assert.strictEqual(propertyNode instanceof PropertyElementSyntaxNode, true);
-          Test.assertSyntaxToken(propertyNode.variable, text, TokenKind.Variable, '$c');
-          assert.strictEqual(propertyNode.expression, null);
+          assert.strictEqual(declNode.type instanceof NamedTypeSyntaxNode, true, 'NamedTypeSyntaxNode');
+          assert.strictEqual((<NamedTypeSyntaxNode>declNode.type).question, null);
+          assertPropertyElements(declNode, text, ['$c']);
         }),
         new ParserTestArgs('class A { public array $c; }', 'should parse a property declaration with predefined type', (statements, text) => {
           let declNode = assertPropertyDeclaration(statements);
           let modifiers = declNode.modifiers ? declNode.modifiers.childTokens() : [];
           assert.strictEqual(modifiers.length, 1);
           Test.assertSyntaxToken(modifiers[0], text, TokenKind.Public, 'public');
-          assert.notStrictEqual(declNode.type, null);
-          assert.strictEqual(declNode.type ? declNode.type.question : false, null);
-          let elements = declNode.properties ? declNode.properties.childNodes() : [];
-          assert.strictEqual(elements.length, 1);
-          let propertyNode = <PropertyElementSyntaxNode>elements[0];
-          assert.strictEqual(propertyNode instanceof PropertyElementSyntaxNode, true);
-          Test.assertSyntaxToken(propertyNode.variable, text, TokenKind.Variable, '$c');
-          assert.strictEqual(propertyNode.expression, null);
+          assert.strictEqual(declNode.type instanceof PredefinedTypeSyntaxNode, true, 'PredefinedTypeSyntaxNode');
+          assert.strictEqual((<PredefinedTypeSyntaxNode>declNode.type).question, null);
+          assertPropertyElements(declNode, text, ['$c']);
         }),
         new ParserTestArgs('class A { public ?B $c; }', 'should parse a property declaration with nullable type', (statements, text) => {
           let declNode = assertPropertyDeclaration(statements);
           let modifiers = declNode.modifiers ? declNode.modifiers.childTokens() : [];
           assert.strictEqual(modifiers.length, 1);
           Test.assertSyntaxToken(modifiers[0], text, TokenKind.Public, 'public');
-          assert.notStrictEqual(declNode.type, null);
-          assert.notStrictEqual(declNode.type ? declNode.type.question : false, null);
-          let elements = declNode.properties ? declNode.properties.childNodes() : [];
-          assert.strictEqual(elements.length, 1);
-          let propertyNode = <PropertyElementSyntaxNode>elements[0];
-          assert.strictEqual(propertyNode instanceof PropertyElementSyntaxNode, true);
-          Test.assertSyntaxToken(propertyNode.variable, text, TokenKind.Variable, '$c');
-          assert.strictEqual(propertyNode.expression, null);
+          assert.strictEqual(declNode.type instanceof NamedTypeSyntaxNode, true, 'NamedTypeSyntaxNode');
+          assert.notStrictEqual((<NamedTypeSyntaxNode>declNode.type).question, null);
+          assertPropertyElements(declNode, text, ['$c']);
         }),
       ];
       Test.assertSyntaxNodes(syntaxTests7_4, PhpVersion.PHP7_4);

--- a/test/src/parser/PhpParserTest_ClassDeclaration.ts
+++ b/test/src/parser/PhpParserTest_ClassDeclaration.ts
@@ -28,6 +28,7 @@ import {
   ClassConstantDeclarationSyntaxNode,
   ClassConstantElementSyntaxNode,
   ClassDeclarationSyntaxNode,
+  CompositeTypeSyntaxNode,
   FullyQualifiedNameSyntaxNode,
   LiteralSyntaxNode,
   MethodDeclarationSyntaxNode,
@@ -45,7 +46,6 @@ import {
   TraitPrecedenceSyntaxNode,
   TraitUseGroupSyntaxNode,
   TraitUseSyntaxNode,
-  TypeSyntaxNode,
 } from '../../../src/language/syntax/SyntaxNode.Generated';
 
 import { ErrorCode } from '../../../src/diagnostics/ErrorCode.Generated';
@@ -488,21 +488,21 @@ describe('PhpParser', function() {
           assert.strictEqual(method.modifiers, null);
           assert.strictEqual(method.ampersand, null);
           Test.assertSyntaxToken(method.identifierOrKeyword, text, TokenKind.Identifier, 'b');
-          assert.strictEqual(method.returnType instanceof TypeSyntaxNode, true);
+          assert.strictEqual(method.returnType instanceof NamedTypeSyntaxNode, true);
         }),
         new ParserTestArgs('class A { function b(): \\C {} }', 'should parse a method declaration with fully qualified return type', (statements, text) => {
           let method = assertMethodDeclaration(statements);
           assert.strictEqual(method.modifiers, null);
           assert.strictEqual(method.ampersand, null);
           Test.assertSyntaxToken(method.identifierOrKeyword, text, TokenKind.Identifier, 'b');
-          assert.strictEqual(method.returnType instanceof TypeSyntaxNode, true);
+          assert.strictEqual(method.returnType instanceof NamedTypeSyntaxNode, true);
         }),
         new ParserTestArgs('class A { function b(): namespace\\C {} }', 'should parse a method declaration with relative return type', (statements, text) => {
           let method = assertMethodDeclaration(statements);
           assert.strictEqual(method.modifiers, null);
           assert.strictEqual(method.ampersand, null);
           Test.assertSyntaxToken(method.identifierOrKeyword, text, TokenKind.Identifier, 'b');
-          assert.strictEqual(method.returnType instanceof TypeSyntaxNode, true);
+          assert.strictEqual(method.returnType instanceof NamedTypeSyntaxNode, true);
         }),
         new ParserTestArgs('class A { function b(): array {} }', 'should parse a method declaration with predefined return type (array)', (statements, text) => {
           let method = assertMethodDeclaration(statements);
@@ -535,6 +535,22 @@ describe('PhpParser', function() {
       ];
       Test.assertSyntaxNodes(syntaxTests7_1, PhpVersion.PHP7_1);
 
+      let syntaxTests8_0 = [
+        new ParserTestArgs('class A { function b(): array | C {} }', 'should parse a method declaration with type union', (statements, text) => {
+          let method = assertMethodDeclaration(statements);
+          assert.strictEqual(method.modifiers, null);
+          assert.strictEqual(method.ampersand, null);
+          Test.assertSyntaxToken(method.identifierOrKeyword, text, TokenKind.Identifier, 'b');
+          let returnType = <CompositeTypeSyntaxNode>method.returnType;
+          assert.strictEqual(returnType instanceof CompositeTypeSyntaxNode, true, 'CompositeTypeSyntaxNode');
+          let types = returnType.types.childNodes();
+          assert.strictEqual(types.length, 2);
+          assert.strictEqual(types[0] instanceof PredefinedTypeSyntaxNode, true);
+          assert.strictEqual(types[1] instanceof NamedTypeSyntaxNode, true);
+        }),
+      ];
+      Test.assertSyntaxNodes(syntaxTests8_0, PhpVersion.PHP8_0);
+
       let diagnosticTests = [
         new DiagnosticTestArgs('class A { function }', 'missing method name or ampersand', [ErrorCode.ERR_MethodNameOrAmpersandExpected], [18]),
         new DiagnosticTestArgs('class A { function &', 'missing method name (after ampersand)', [ErrorCode.ERR_MethodNameExpected], [20]),
@@ -542,14 +558,31 @@ describe('PhpParser', function() {
         new DiagnosticTestArgs('class A { function b( }', 'missing ampersand, ellipsis, question, type, variable, or close paren', [ErrorCode.ERR_ParameterOrCloseParenExpected], [21]),
         new DiagnosticTestArgs('class A { function b() }', 'missing open brace or colon', [ErrorCode.ERR_OpenBraceOrColonExpected], [22]),
         new DiagnosticTestArgs('class A { function b() { }', 'missing close brace', [ErrorCode.ERR_CloseBraceExpected], [26]),
-        new DiagnosticTestArgs('class A { function b() { public $c; }', 'missing close brace with trailing class member', [ErrorCode.ERR_CloseBraceExpected], [24]),
-
         new DiagnosticTestArgs('class A { function b():', 'missing return type', [ErrorCode.ERR_TypeExpected], [23]),
-        new DiagnosticTestArgs('class A { function b(): C\\ }', 'missing identifier in return type', [ErrorCode.ERR_IdentifierExpected], [26]),
-        new DiagnosticTestArgs('class A { function b(): \\ }', 'missing identifier in return type (fully qualified name)', [ErrorCode.ERR_IdentifierExpected], [25]),
+        new DiagnosticTestArgs('class A { abstract function b() }', 'missing colon or semicolon', [ErrorCode.ERR_ColonOrSemicolonExpected], [31]),
+
+        new DiagnosticTestArgs('class A { function b() { public $c; }', 'should not parse trailing class member as method statement', [ErrorCode.ERR_CloseBraceExpected], [24]),
         new DiagnosticTestArgs('class A { function b(); }', 'should not expect a semicolon after a non-abstract method declaration', [ErrorCode.ERR_OpenBraceOrColonExpected], [22]),
       ];
       Test.assertDiagnostics(diagnosticTests);
+
+      let diagnosticTests8_0 = [
+        new DiagnosticTestArgs('class A { function b(): C }', 'missing open brace or vertical bar', [ErrorCode.ERR_OpenBraceExpected], [25]),
+        new DiagnosticTestArgs('class A { function b(): C | }', 'missing type', [ErrorCode.ERR_TypeExpected], [27]),
+        new DiagnosticTestArgs('class A { function b(): C | D }', 'missing open brace or vertical bar (after multiple types)', [ErrorCode.ERR_OpenBraceExpected], [29]),
+        new DiagnosticTestArgs('class A { abstract function b(): C }', 'missing semicolon or vertical bar', [ErrorCode.ERR_SemicolonExpected], [34]),
+
+        new DiagnosticTestArgs('class A { function b(): ?C | D {} }', 'should not parse nullable type in type union', [ErrorCode.ERR_TypeUnionHasNullableType], [24]),
+        new DiagnosticTestArgs('class A { function b(): ?C | ?D {} }', 'should not parse nullable type in type union (multiple)', [ErrorCode.ERR_TypeUnionHasNullableType, ErrorCode.ERR_TypeUnionHasNullableType], [24, 29]),
+      ];
+      Test.assertDiagnostics(diagnosticTests8_0, PhpVersion.PHP8_0);
+
+      let diagnosticRegressionTests8_0 = [
+        new DiagnosticTestArgs('class A { function b(): C', 'missing open brace', [ErrorCode.ERR_OpenBraceExpected], [25]),
+        new DiagnosticTestArgs('class A { function b(): C | D {} }', 'should not parse a type union', [ErrorCode.ERR_FeatureUnionTypes], [24]),
+        new DiagnosticTestArgs('class A { abstract function b(): C }', 'missing semicolon', [ErrorCode.ERR_SemicolonExpected], [34]),
+      ];
+      Test.assertDiagnostics(diagnosticRegressionTests8_0, PhpVersion.PHP7_0, PhpVersion.PHP7_4);
     });
 
     describe('method-declaration (modifiers)', function() {
@@ -689,6 +722,7 @@ describe('PhpParser', function() {
         new DiagnosticTestArgs('class A { abstract function b() {} }', 'should not expect method body on abstract method', [ErrorCode.ERR_AbstractMethodHasBody], [32]),
         new DiagnosticTestArgs('class A { abstract final function b(); }', 'should not expect abstract and final modifiers', [ErrorCode.ERR_AbstractMemberIsFinal], [19]),
         new DiagnosticTestArgs('class A { abstract private function b(); }', 'should not expect abstract and private modifiers', [ErrorCode.ERR_AbstractMemberIsPrivate], [19]),
+        new DiagnosticTestArgs('class A { abstract function b() {} }', 'should not expect method body on abstract method', [ErrorCode.ERR_AbstractMethodHasBody], [32]),
       ];
       Test.assertDiagnostics(diagnosticTests);
     });
@@ -880,6 +914,21 @@ describe('PhpParser', function() {
       ];
       Test.assertSyntaxNodes(syntaxTests7_4, PhpVersion.PHP7_4);
 
+      let syntaxTests8_0 = [
+        new ParserTestArgs('class A { public B | callable $d; }', 'should parse a property declaration with type union', (statements, text) => {
+          let declNode = assertPropertyDeclaration(statements);
+          let modifiers = declNode.modifiers ? declNode.modifiers.childTokens() : [];
+          assert.strictEqual(modifiers.length, 1);
+          Test.assertSyntaxToken(modifiers[0], text, TokenKind.Public, 'public');
+          assert.strictEqual(declNode.type instanceof CompositeTypeSyntaxNode, true, 'CompositeTypeSyntaxNode');
+          let types = (<CompositeTypeSyntaxNode>declNode.type).types.childNodes();
+          assert.strictEqual(types.length, 2);
+          assert.strictEqual(types[0] instanceof NamedTypeSyntaxNode, true);
+          assert.strictEqual(types[1] instanceof PredefinedTypeSyntaxNode, true);
+        }),
+      ];
+      Test.assertSyntaxNodes(syntaxTests8_0, PhpVersion.PHP8_0);
+
       let diagnosticTests = [
         new DiagnosticTestArgs('class A { public $ }', 'incomplete property name', [ErrorCode.ERR_PropertyNameExpected], [17]),
         new DiagnosticTestArgs('class A { public $b', 'missing assignment, comma, or semicolon', [ErrorCode.ERR_IncompletePropertyDeclaration], [19]),
@@ -900,10 +949,24 @@ describe('PhpParser', function() {
       ];
       Test.assertDiagnostics(diagnosticTests7_4, PhpVersion.PHP7_4);
 
-      let featureTypedProperties = [
+      let diagnosticRegressionTests7_4 = [
         new DiagnosticTestArgs('class A { public B $c; }', 'should not parse a typed property', [ErrorCode.ERR_FeatureTypedProperties], [17]),
       ];
-      Test.assertDiagnostics(featureTypedProperties, PhpVersion.PHP7_0, PhpVersion.PHP7_3);
+      Test.assertDiagnostics(diagnosticRegressionTests7_4, PhpVersion.PHP7_0, PhpVersion.PHP7_3);
+
+      let diagnosticTests8_0 = [
+        new DiagnosticTestArgs('class A { public B }', 'missing vertical bar or property', [ErrorCode.ERR_PropertyExpected], [18]),
+        new DiagnosticTestArgs('class A { public B | }', 'missing type', [ErrorCode.ERR_TypeExpected], [20]),
+        new DiagnosticTestArgs('class A { public B | C }', 'missing vertical bar or property (after multiple types)', [ErrorCode.ERR_PropertyExpected], [22]),
+        new DiagnosticTestArgs('class A { public ?B | C $d; }', 'should not parse nullable type in type union', [ErrorCode.ERR_TypeUnionHasNullableType], [17]),
+        new DiagnosticTestArgs('class A { public ?B | ?C $d; }', 'should not parse nullable type in type union (multiple)', [ErrorCode.ERR_TypeUnionHasNullableType, ErrorCode.ERR_TypeUnionHasNullableType], [17, 22]),
+      ];
+      Test.assertDiagnostics(diagnosticTests8_0, PhpVersion.PHP8_0);
+
+      let diagnosticRegressionTests8_0 = [
+        new DiagnosticTestArgs('class A { public B | C $d; }', 'should not parse a property with a type union', [ErrorCode.ERR_FeatureUnionTypes], [17]),
+      ];
+      Test.assertDiagnostics(diagnosticRegressionTests8_0, PhpVersion.PHP7_0, PhpVersion.PHP7_4);
     });
 
     describe('trait-use-clause', function() {

--- a/test/src/parser/PhpParserTest_Expressions.ts
+++ b/test/src/parser/PhpParserTest_Expressions.ts
@@ -942,6 +942,18 @@ describe('PhpParser', function() {
     ];
     Test.assertSyntaxNodes(syntaxTests);
 
+    let syntaxTests8_0 = [
+      new ParserTestArgs('new $a?->b;', 'should parse an object creation expression with class reference using null-safe member access', (statements) => {
+        let exprNode = <ExpressionStatementSyntaxNode>statements[0];
+        assert.strictEqual(exprNode instanceof ExpressionStatementSyntaxNode, true, 'ExpressionStatementSyntaxNode');
+        let newNode = <IndirectObjectCreationSyntaxNode>exprNode.expression;
+        assert.strictEqual(newNode instanceof IndirectObjectCreationSyntaxNode, true);
+        assert.strictEqual(newNode.classNameReference instanceof NamedMemberAccessSyntaxNode, true, 'NamedMemberAccessSyntaxNode');
+        assert.strictEqual(newNode.argumentList, null);
+      }),
+    ];
+    Test.assertSyntaxNodes(syntaxTests8_0, PhpVersion.PHP8_0);
+
     let syntaxRegressionTests8_0 = [
       new ParserTestArgs('new $a{0};', 'should parse an object creation expression with class reference using element access (brace syntax)', (statements) => {
         let exprNode = <ExpressionStatementSyntaxNode>statements[0];

--- a/test/src/parser/PhpParserTest_Expressions.ts
+++ b/test/src/parser/PhpParserTest_Expressions.ts
@@ -1333,20 +1333,24 @@ describe('PhpParser', function() {
           Test.assertSyntaxToken(castNode.operator, text, TokenKind.ObjectCast, '(object)');
           assert.strictEqual(castNode.operand instanceof LocalVariableSyntaxNode, true);
         }),
-        new ParserTestArgs('(real)$a;', 'should parse a real cast', (statements, text) => {
-          let exprNode = <ExpressionStatementSyntaxNode>statements[0];
-          assert.strictEqual(exprNode instanceof ExpressionStatementSyntaxNode, true, 'ExpressionStatementSyntaxNode');
-          let castNode = <UnarySyntaxNode>exprNode.expression;
-          assert.strictEqual(castNode instanceof UnarySyntaxNode, true);
-          Test.assertSyntaxToken(castNode.operator, text, TokenKind.RealCast, '(real)');
-          assert.strictEqual(castNode.operand instanceof LocalVariableSyntaxNode, true);
-        }),
         new ParserTestArgs('(string)$a;', 'should parse a string cast', (statements, text) => {
           let exprNode = <ExpressionStatementSyntaxNode>statements[0];
           assert.strictEqual(exprNode instanceof ExpressionStatementSyntaxNode, true, 'ExpressionStatementSyntaxNode');
           let castNode = <UnarySyntaxNode>exprNode.expression;
           assert.strictEqual(castNode instanceof UnarySyntaxNode, true);
           Test.assertSyntaxToken(castNode.operator, text, TokenKind.StringCast, '(string)');
+          assert.strictEqual(castNode.operand instanceof LocalVariableSyntaxNode, true);
+        }),
+      ];
+      Test.assertSyntaxNodes(syntaxTests);
+
+      let syntaxRegressionTests8_0 = [
+        new ParserTestArgs('(real)$a;', 'should parse a real cast', (statements, text) => {
+          let exprNode = <ExpressionStatementSyntaxNode>statements[0];
+          assert.strictEqual(exprNode instanceof ExpressionStatementSyntaxNode, true, 'ExpressionStatementSyntaxNode');
+          let castNode = <UnarySyntaxNode>exprNode.expression;
+          assert.strictEqual(castNode instanceof UnarySyntaxNode, true);
+          Test.assertSyntaxToken(castNode.operator, text, TokenKind.RealCast, '(real)');
           assert.strictEqual(castNode.operand instanceof LocalVariableSyntaxNode, true);
         }),
         new ParserTestArgs('(unset)$a;', 'should parse an unset cast', (statements, text) => {
@@ -1358,7 +1362,7 @@ describe('PhpParser', function() {
           assert.strictEqual(castNode.operand instanceof LocalVariableSyntaxNode, true);
         }),
       ];
-      Test.assertSyntaxNodes(syntaxTests);
+      Test.assertSyntaxNodes(syntaxRegressionTests8_0, PhpVersion.PHP7_0, PhpVersion.PHP7_4);
 
       let diagnosticTests = [
         new DiagnosticTestArgs('(array)', 'missing expression (array)', [ErrorCode.ERR_ExpressionExpectedEOF], [7]),
@@ -1370,11 +1374,15 @@ describe('PhpParser', function() {
         new DiagnosticTestArgs('(int)', 'missing expression (int)', [ErrorCode.ERR_ExpressionExpectedEOF], [5]),
         new DiagnosticTestArgs('(integer)', 'missing expression (integer)', [ErrorCode.ERR_ExpressionExpectedEOF], [9]),
         new DiagnosticTestArgs('(object)', 'missing expression (object)', [ErrorCode.ERR_ExpressionExpectedEOF], [8]),
-        new DiagnosticTestArgs('(real)', 'missing expression (real)', [ErrorCode.WRN_RealCast, ErrorCode.ERR_ExpressionExpectedEOF], [0, 6]),
         new DiagnosticTestArgs('(string)', 'missing expression (string)', [ErrorCode.ERR_ExpressionExpectedEOF], [8]),
-        new DiagnosticTestArgs('(unset)', 'missing expression (unset)', [ErrorCode.WRN_UnsetCast, ErrorCode.ERR_ExpressionExpectedEOF], [0, 7]),
       ];
       Test.assertDiagnostics(diagnosticTests);
+
+      let diagnosticRegressionTests8_0 = [
+        new DiagnosticTestArgs('(real)', 'missing expression (real)', [ErrorCode.WRN_RealCast, ErrorCode.ERR_ExpressionExpectedEOF], [0, 6]),
+        new DiagnosticTestArgs('(unset)', 'missing expression (unset)', [ErrorCode.WRN_UnsetCast, ErrorCode.ERR_ExpressionExpectedEOF], [0, 7]),
+      ];
+      Test.assertDiagnostics(diagnosticRegressionTests8_0, PhpVersion.PHP7_0, PhpVersion.PHP7_4);
     });
 
     describe('logical-not-expression', function() {

--- a/test/src/parser/PhpParserTest_Expressions.ts
+++ b/test/src/parser/PhpParserTest_Expressions.ts
@@ -808,7 +808,7 @@ describe('PhpParser', function() {
       new DiagnosticTestArgs('fn(): A | B => $c;', 'should not parse a type union', [ErrorCode.ERR_FeatureUnionTypes], [6]),
       new DiagnosticTestArgs('fn(): static => $a;', 'should not parse a static return type', [ErrorCode.ERR_FeatureStaticReturnType], [6]),
     ];
-    Test.assertDiagnostics(diagnosticRegressionTests8_0, PhpVersion.PHP7_0, PhpVersion.PHP7_4);
+    Test.assertDiagnostics(diagnosticRegressionTests8_0, PhpVersion.PHP7_4, PhpVersion.PHP7_4);
   });
 
   describe('object-creation-expression (new-expression)', function() {

--- a/test/src/parser/PhpParserTest_Expressions.ts
+++ b/test/src/parser/PhpParserTest_Expressions.ts
@@ -492,7 +492,8 @@ describe('PhpParser', function() {
       Test.assertDiagnostics(diagnosticTests7_3, PhpVersion.PHP7_3);
 
       let featureTrailingCommas = [
-        new DiagnosticTestArgs('isset($a,);', 'should not parse trailing comma in argument list', [ErrorCode.ERR_FeatureTrailingCommasInArgumentLists], [8]),
+        new DiagnosticTestArgs('isset($a,', 'should not parse trailing comma in argument list', [ErrorCode.ERR_FeatureTrailingCommasInArgumentLists, ErrorCode.ERR_ExpressionOrCloseParenExpected], [8, 9]),
+        new DiagnosticTestArgs('isset($a,);', 'should not parse trailing comma in argument list (completed)', [ErrorCode.ERR_FeatureTrailingCommasInArgumentLists], [8]),
         new DiagnosticTestArgs('isset($a, $b,);', 'should not parse trailing comma in argument list (multiple arguments)', [ErrorCode.ERR_FeatureTrailingCommasInArgumentLists], [12]),
       ];
       Test.assertDiagnostics(featureTrailingCommas, PhpVersion.PHP7_0, PhpVersion.PHP7_2);
@@ -697,8 +698,8 @@ describe('PhpParser', function() {
     Test.assertDiagnostics(diagnosticTests8_0, PhpVersion.PHP8_0);
 
     let diagnosticRegressionTests8_0 = [
-      new DiagnosticTestArgs('function() use($a,', 'should not parse trailing comma in closure use list (incomplete)', [ErrorCode.ERR_FeatureTrailingCommasInClosureUseLists, ErrorCode.ERR_IncompleteClosureUseList], [17, 18]),
-      new DiagnosticTestArgs('function() use($a,)', 'should not parse trailing comma in closure use list', [ErrorCode.ERR_FeatureTrailingCommasInClosureUseLists], [17]),
+      new DiagnosticTestArgs('function() use($a,', 'should not parse trailing comma in closure use list', [ErrorCode.ERR_FeatureTrailingCommasInClosureUseLists, ErrorCode.ERR_IncompleteClosureUseList], [17, 18]),
+      new DiagnosticTestArgs('function() use($a,)', 'should not parse trailing comma in closure use list (completed)', [ErrorCode.ERR_FeatureTrailingCommasInClosureUseLists], [17]),
     ];
     Test.assertDiagnostics(diagnosticRegressionTests8_0, PhpVersion.PHP7_0, PhpVersion.PHP7_4);
   });

--- a/test/src/parser/PhpParserTest_Expressions.ts
+++ b/test/src/parser/PhpParserTest_Expressions.ts
@@ -64,6 +64,7 @@ import {
   RelativeNameSyntaxNode,
   ScriptInclusionSyntaxNode,
   StaticPropertySyntaxNode,
+  ThrowExpressionSyntaxNode,
   UnarySyntaxNode,
   YieldFromSyntaxNode,
   YieldSyntaxNode,
@@ -1827,6 +1828,25 @@ describe('PhpParser', function() {
       }),
     ];
     Test.assertSyntaxNodes(syntaxTests, PhpVersion.PHP8_0);
+  });
+
+  // See also 'throw-statement'.
+  describe('throw-expression', function() {
+    let syntaxTests = [
+      new ParserTestArgs('throw $e;', 'should parse a throw expression', (statements) => {
+        let exprNode = <ExpressionStatementSyntaxNode>statements[0];
+        assert.strictEqual(exprNode instanceof ExpressionStatementSyntaxNode, true, 'ExpressionStatementSyntaxNode');
+        let throwExpr = <ThrowExpressionSyntaxNode>exprNode.expression;
+        assert.strictEqual(throwExpr instanceof ThrowExpressionSyntaxNode, true, 'ThrowExpressionSyntaxNode');
+        assert.strictEqual(throwExpr.expression instanceof LocalVariableSyntaxNode, true);
+      }),
+    ];
+    Test.assertSyntaxNodes(syntaxTests, PhpVersion.PHP8_0);
+
+    let diagnosticTests = [
+      new DiagnosticTestArgs('throw', 'missing expression', [ErrorCode.ERR_ExpressionExpectedEOF], [5]),
+    ];
+    Test.assertDiagnostics(diagnosticTests, PhpVersion.PHP8_0);
   });
 
 });

--- a/test/src/parser/PhpParserTest_Expressions.ts
+++ b/test/src/parser/PhpParserTest_Expressions.ts
@@ -229,6 +229,23 @@ describe('PhpParser', function() {
       }),
     ];
     Test.assertSyntaxNodes(syntaxTests);
+
+    let syntaxTests8_0 = [
+      new ParserTestArgs('$a < $b . $c;', 'relational < concatenate', (statements, text) => {
+        assertPrecedence(statements, text, TokenKind.LessThan, '<', TokenKind.Period, '.');
+      }),
+      new ParserTestArgs('$a . $b << $c;', 'concatenate < shift', (statements, text) => {
+        assertPrecedence(statements, text, TokenKind.Period, '.', TokenKind.ShiftLeft, '<<');
+      }),
+    ];
+    Test.assertSyntaxNodes(syntaxTests8_0, PhpVersion.PHP8_0);
+
+    let deprecatedConcatPrecedence = [
+      new ParserTestArgs('$a << $b . $c;', 'shift < add (concatenate)', (statements, text) => {
+        assertPrecedence(statements, text, TokenKind.ShiftLeft, '<<', TokenKind.Period, '.');
+      }),
+    ];
+    Test.assertSyntaxNodes(deprecatedConcatPrecedence, PhpVersion.PHP7_0, PhpVersion.PHP7_4);
   });
 
   describe('literal', function() {

--- a/test/src/parser/PhpParserTest_Expressions_Binary.ts
+++ b/test/src/parser/PhpParserTest_Expressions_Binary.ts
@@ -123,7 +123,7 @@ function assertListDeconstruction(statements: ISyntaxNode[]): ListDestructureSyn
 
 describe('PhpParser', function() {
 
-  describe('binary expressions', function() {
+  describe('associativity', function() {
 
     describe('left associative operators', function() {
       let syntaxTests = [
@@ -278,44 +278,9 @@ describe('PhpParser', function() {
       Test.assertDiagnostics(diagnosticTests);
     });
 
-    describe('instanceof-expression', function() {
-      // See `object-creation-expression` for full tests of `class-name-reference`.
-      let syntaxTests = [
-        new ParserTestArgs('$a instanceof A;', 'should parse an instanceof expression', (statements, text) => {
-          let exprNode = <ExpressionStatementSyntaxNode>statements[0];
-          assert.strictEqual(exprNode instanceof ExpressionStatementSyntaxNode, true, 'ExpressionStatementSyntaxNode');
-          let binaryNode = <InstanceOfSyntaxNode>exprNode.expression;
-          assert.strictEqual(binaryNode instanceof InstanceOfSyntaxNode, true, 'BinarySyntaxNode');
-          assert.strictEqual(binaryNode.operand instanceof LocalVariableSyntaxNode, true, 'LocalVariableSyntaxNode');
-          Test.assertSyntaxToken(binaryNode.instanceOfKeyword, text, TokenKind.InstanceOf, 'instanceof');
-          assert.strictEqual(binaryNode.classNameOrReference instanceof PartiallyQualifiedNameSyntaxNode, true, 'PartiallyQualifiedNameSyntaxNode');
-        }),
-      ];
-      Test.assertSyntaxNodes(syntaxTests);
+  });
 
-      let diagnosticTests = [
-        new DiagnosticTestArgs('$a instanceof', 'missing name or reference', [ErrorCode.ERR_ClassNameOrReferenceExpected], [13]),
-      ];
-      Test.assertDiagnostics(diagnosticTests);
-    });
-
-    describe('multiplicative-expression', function() {
-      let syntaxTests = [
-        new ParserTestArgs('$a * 2;', 'should parse a multiply expression', (statements, text) => {
-          let binaryExpr = assertBinaryNode(statements);
-          Test.assertSyntaxToken(binaryExpr.operator, text, TokenKind.Asterisk, '*');
-        }),
-        new ParserTestArgs('$a / 2;', 'should parse a divide expression', (statements, text) => {
-          let binaryExpr = assertBinaryNode(statements);
-          Test.assertSyntaxToken(binaryExpr.operator, text, TokenKind.Slash, '/');
-        }),
-        new ParserTestArgs('$a % 2;', 'should parse a modulus expression', (statements, text) => {
-          let binaryExpr = assertBinaryNode(statements);
-          Test.assertSyntaxToken(binaryExpr.operator, text, TokenKind.Percent, '%');
-        }),
-      ];
-      Test.assertSyntaxNodes(syntaxTests);
-    });
+  describe('binary expressions', function() {
 
     describe('additive-expression', function() {
       let syntaxTests = [
@@ -330,72 +295,6 @@ describe('PhpParser', function() {
         new ParserTestArgs('$a . "";', 'should parse a concatenation expression', (statements, text) => {
           let binaryExpr = assertBinaryNode(statements);
           Test.assertSyntaxToken(binaryExpr.operator, text, TokenKind.Period, '.');
-        }),
-      ];
-      Test.assertSyntaxNodes(syntaxTests);
-    });
-
-    describe('shift-expression', function() {
-      let syntaxTests = [
-        new ParserTestArgs('$a << 1;', 'should parse a left shift expression', (statements, text) => {
-          let binaryExpr = assertBinaryNode(statements);
-          Test.assertSyntaxToken(binaryExpr.operator, text, TokenKind.ShiftLeft, '<<');
-        }),
-        new ParserTestArgs('$a >> 1;', 'should parse a right shift expression', (statements, text) => {
-          let binaryExpr = assertBinaryNode(statements);
-          Test.assertSyntaxToken(binaryExpr.operator, text, TokenKind.ShiftRight, '>>');
-        }),
-      ];
-      Test.assertSyntaxNodes(syntaxTests);
-    });
-
-    describe('relational-expression', function() {
-      let syntaxTests = [
-        new ParserTestArgs('$a < 1;', 'should parse a less than expression', (statements, text) => {
-          let binaryExpr = assertBinaryNode(statements);
-          Test.assertSyntaxToken(binaryExpr.operator, text, TokenKind.LessThan, '<');
-        }),
-        new ParserTestArgs('$a > 1;', 'should parse a greater than expression', (statements, text) => {
-          let binaryExpr = assertBinaryNode(statements);
-          Test.assertSyntaxToken(binaryExpr.operator, text, TokenKind.GreaterThan, '>');
-        }),
-        new ParserTestArgs('$a <= 1;', 'should parse a less than or equal expression', (statements, text) => {
-          let binaryExpr = assertBinaryNode(statements);
-          Test.assertSyntaxToken(binaryExpr.operator, text, TokenKind.IsLessThanOrEqual, '<=');
-        }),
-        new ParserTestArgs('$a >= 1;', 'should parse a greater than or equal expression', (statements, text) => {
-          let binaryExpr = assertBinaryNode(statements);
-          Test.assertSyntaxToken(binaryExpr.operator, text, TokenKind.IsGreaterThanOrEqual, '>=');
-        }),
-        new ParserTestArgs('$a <=> 1;', 'should parse a spaceship expression', (statements, text) => {
-          let binaryExpr = assertBinaryNode(statements);
-          Test.assertSyntaxToken(binaryExpr.operator, text, TokenKind.Spaceship, '<=>');
-        }),
-      ];
-      Test.assertSyntaxNodes(syntaxTests);
-    });
-
-    describe('equality-expression', function() {
-      let syntaxTests = [
-        new ParserTestArgs('$a == 1;', 'should parse an is equal expression', (statements, text) => {
-          let binaryExpr = assertBinaryNode(statements);
-          Test.assertSyntaxToken(binaryExpr.operator, text, TokenKind.IsEqual, '==');
-        }),
-        new ParserTestArgs('$a != 1;', 'should parse an is not equal expression', (statements, text) => {
-          let binaryExpr = assertBinaryNode(statements);
-          Test.assertSyntaxToken(binaryExpr.operator, text, TokenKind.IsNotEqual, '!=');
-        }),
-        new ParserTestArgs('$a <> 1;', 'should parse an is not equal expression (alternate syntax)', (statements, text) => {
-          let binaryExpr = assertBinaryNode(statements);
-          Test.assertSyntaxToken(binaryExpr.operator, text, TokenKind.Inequality, '<>');
-        }),
-        new ParserTestArgs('$a === 1;', 'should parse an is strict equal expression', (statements, text) => {
-          let binaryExpr = assertBinaryNode(statements);
-          Test.assertSyntaxToken(binaryExpr.operator, text, TokenKind.IsIdentical, '===');
-        }),
-        new ParserTestArgs('$a !== 1;', 'should parse an is not strict equal expression', (statements, text) => {
-          let binaryExpr = assertBinaryNode(statements);
-          Test.assertSyntaxToken(binaryExpr.operator, text, TokenKind.IsNotIdentical, '!==');
         }),
       ];
       Test.assertSyntaxNodes(syntaxTests);
@@ -419,27 +318,11 @@ describe('PhpParser', function() {
       Test.assertSyntaxNodes(syntaxTests);
     });
 
-    describe('logical-*-expression', function() {
+    describe('coalesce-expression', function() {
       let syntaxTests = [
-        new ParserTestArgs('$a && 1;', 'should parse a logical and expression', (statements, text) => {
+        new ParserTestArgs('$a ?? 1;', 'should parse a coalesce expression', (statements, text) => {
           let binaryExpr = assertBinaryNode(statements);
-          Test.assertSyntaxToken(binaryExpr.operator, text, TokenKind.BooleanAnd, '&&');
-        }),
-        new ParserTestArgs('$a || 1;', 'should parse a logical or expression', (statements, text) => {
-          let binaryExpr = assertBinaryNode(statements);
-          Test.assertSyntaxToken(binaryExpr.operator, text, TokenKind.BooleanOr, '||');
-        }),
-        new ParserTestArgs('$a and 1;', 'should parse a logical and expression (alternate syntax)', (statements, text) => {
-          let binaryExpr = assertBinaryNode(statements);
-          Test.assertSyntaxToken(binaryExpr.operator, text, TokenKind.LogicalAnd, 'and');
-        }),
-        new ParserTestArgs('$a or 1;', 'should parse a logical or expression (alternate syntax)', (statements, text) => {
-          let binaryExpr = assertBinaryNode(statements);
-          Test.assertSyntaxToken(binaryExpr.operator, text, TokenKind.LogicalOr, 'or');
-        }),
-        new ParserTestArgs('$a xor 1;', 'should parse a logical xor expression', (statements, text) => {
-          let binaryExpr = assertBinaryNode(statements);
-          Test.assertSyntaxToken(binaryExpr.operator, text, TokenKind.LogicalXor, 'xor');
+          Test.assertSyntaxToken(binaryExpr.operator, text, TokenKind.Coalesce, '??');
         }),
       ];
       Test.assertSyntaxNodes(syntaxTests);
@@ -477,356 +360,481 @@ describe('PhpParser', function() {
       Test.assertDiagnostics(diagnosticTests);
     });
 
-    describe('coalesce-expression', function() {
+    describe('equality-expression', function() {
       let syntaxTests = [
-        new ParserTestArgs('$a ?? 1;', 'should parse a coalesce expression', (statements, text) => {
+        new ParserTestArgs('$a == 1;', 'should parse an is equal expression', (statements, text) => {
           let binaryExpr = assertBinaryNode(statements);
-          Test.assertSyntaxToken(binaryExpr.operator, text, TokenKind.Coalesce, '??');
+          Test.assertSyntaxToken(binaryExpr.operator, text, TokenKind.IsEqual, '==');
+        }),
+        new ParserTestArgs('$a != 1;', 'should parse an is not equal expression', (statements, text) => {
+          let binaryExpr = assertBinaryNode(statements);
+          Test.assertSyntaxToken(binaryExpr.operator, text, TokenKind.IsNotEqual, '!=');
+        }),
+        new ParserTestArgs('$a <> 1;', 'should parse an is not equal expression (alternate syntax)', (statements, text) => {
+          let binaryExpr = assertBinaryNode(statements);
+          Test.assertSyntaxToken(binaryExpr.operator, text, TokenKind.Inequality, '<>');
+        }),
+        new ParserTestArgs('$a === 1;', 'should parse an is strict equal expression', (statements, text) => {
+          let binaryExpr = assertBinaryNode(statements);
+          Test.assertSyntaxToken(binaryExpr.operator, text, TokenKind.IsIdentical, '===');
+        }),
+        new ParserTestArgs('$a !== 1;', 'should parse an is not strict equal expression', (statements, text) => {
+          let binaryExpr = assertBinaryNode(statements);
+          Test.assertSyntaxToken(binaryExpr.operator, text, TokenKind.IsNotIdentical, '!==');
         }),
       ];
       Test.assertSyntaxNodes(syntaxTests);
     });
 
-    describe('assignment-expression', function() {
+    describe('instanceof-expression', function() {
+      // See `object-creation-expression` for full tests of `class-name-reference`.
       let syntaxTests = [
-        new ParserTestArgs('$a = 1;', 'should parse an assignment expression', (statements) => {
+        new ParserTestArgs('$a instanceof A;', 'should parse an instanceof expression', (statements, text) => {
           let exprNode = <ExpressionStatementSyntaxNode>statements[0];
           assert.strictEqual(exprNode instanceof ExpressionStatementSyntaxNode, true, 'ExpressionStatementSyntaxNode');
-          let assignmentNode = <AssignmentSyntaxNode>exprNode.expression;
-          assert.strictEqual(assignmentNode instanceof AssignmentSyntaxNode, true);
-          assert.strictEqual(assignmentNode.leftOperand instanceof LocalVariableSyntaxNode, true);
-          assert.strictEqual(assignmentNode.ampersand, null);
-          assert.strictEqual(assignmentNode.rightOperand instanceof LiteralSyntaxNode, true);
-        }),
-        new ParserTestArgs('$a =& $b;', 'should parse a byref assignment expression', (statements) => {
-          let exprNode = <ExpressionStatementSyntaxNode>statements[0];
-          assert.strictEqual(exprNode instanceof ExpressionStatementSyntaxNode, true, 'ExpressionStatementSyntaxNode');
-          let assignmentNode = <AssignmentSyntaxNode>exprNode.expression;
-          assert.strictEqual(assignmentNode instanceof AssignmentSyntaxNode, true);
-          assert.strictEqual(assignmentNode.leftOperand instanceof LocalVariableSyntaxNode, true);
-          assert.notStrictEqual(assignmentNode.ampersand, null);
-          assert.strictEqual(assignmentNode.rightOperand instanceof LocalVariableSyntaxNode, true);
-        }),
-        // Expected: !($a = 1)
-        new ParserTestArgs('!$a = 1;', 'should parse lhs of assignment as explicit expression (unary)', (statements) => {
-          let exprNode = <ExpressionStatementSyntaxNode>statements[0];
-          assert.strictEqual(exprNode instanceof ExpressionStatementSyntaxNode, true, 'ExpressionStatementSyntaxNode');
-          let parentNode = <UnarySyntaxNode>exprNode.expression;
-          assert.strictEqual(parentNode instanceof UnarySyntaxNode, true, 'UnarySyntaxNode');
-          let childNode = <AssignmentSyntaxNode>parentNode.operand;
-          assert.strictEqual(childNode instanceof AssignmentSyntaxNode, true, 'AssignmentSyntaxNode');
-          assert.strictEqual(childNode.leftOperand instanceof LocalVariableSyntaxNode, true);
-        }),
-        // Expected: $a == ($b = 1)
-        new ParserTestArgs('$a == $b = 1;', 'should parse lhs of assignment as explicit expression (binary)', (statements) => {
-          let exprNode = <ExpressionStatementSyntaxNode>statements[0];
-          assert.strictEqual(exprNode instanceof ExpressionStatementSyntaxNode, true, 'ExpressionStatementSyntaxNode');
-          let binaryNode = <BinarySyntaxNode>exprNode.expression;
-          assert.strictEqual(binaryNode instanceof BinarySyntaxNode, true, 'BinarySyntaxNode');
-          let assignmentNode = <AssignmentSyntaxNode>binaryNode.rightOperand;
-          assert.strictEqual(assignmentNode instanceof AssignmentSyntaxNode, true, 'AssignmentSyntaxNode');
-          assert.strictEqual(assignmentNode.leftOperand instanceof LocalVariableSyntaxNode, true);
-        }),
-        new ParserTestArgs('$a =& $b + $c;', 'should parse rhs of byref assignment as explicit expression', (statements) => {
-          let exprNode = <ExpressionStatementSyntaxNode>statements[0];
-          assert.strictEqual(exprNode instanceof ExpressionStatementSyntaxNode, true, 'ExpressionStatementSyntaxNode');
-          let binaryNode = <BinarySyntaxNode>exprNode.expression;
-          assert.strictEqual(binaryNode instanceof BinarySyntaxNode, true, 'BinarySyntaxNode');
-          assert.strictEqual(binaryNode.rightOperand instanceof LocalVariableSyntaxNode, true);
-          let assignmentNode = <AssignmentSyntaxNode>binaryNode.leftOperand;
-          assert.strictEqual(assignmentNode instanceof AssignmentSyntaxNode, true, 'AssignmentSyntaxNode');
-          assert.strictEqual(assignmentNode.leftOperand instanceof LocalVariableSyntaxNode, true);
-          assert.strictEqual(assignmentNode.rightOperand instanceof LocalVariableSyntaxNode, true);
+          let binaryNode = <InstanceOfSyntaxNode>exprNode.expression;
+          assert.strictEqual(binaryNode instanceof InstanceOfSyntaxNode, true, 'BinarySyntaxNode');
+          assert.strictEqual(binaryNode.operand instanceof LocalVariableSyntaxNode, true, 'LocalVariableSyntaxNode');
+          Test.assertSyntaxToken(binaryNode.instanceOfKeyword, text, TokenKind.InstanceOf, 'instanceof');
+          assert.strictEqual(binaryNode.classNameOrReference instanceof PartiallyQualifiedNameSyntaxNode, true, 'PartiallyQualifiedNameSyntaxNode');
         }),
       ];
       Test.assertSyntaxNodes(syntaxTests);
 
       let diagnosticTests = [
-        new DiagnosticTestArgs('$a =& 1;', 'should expect explicit expression in rhs of byref assignment', [ErrorCode.ERR_ExpressionNotAddressable], [6]),
+        new DiagnosticTestArgs('$a instanceof', 'missing name or reference', [ErrorCode.ERR_ClassNameOrReferenceExpected], [13]),
       ];
       Test.assertDiagnostics(diagnosticTests);
     });
 
-    describe('destructuring-assignment-expression', function() {
+    describe('logical-*-expression', function() {
       let syntaxTests = [
-        new ParserTestArgs('list($a) = $b;', 'should parse a destructuring assignment', (statements) => {
-          let list = assertListDeconstruction(statements);
-          let elements = list.variables ? list.variables.childNodes() : [];
-          assert.strictEqual(elements.length, 1);
-          let element = <ListDestructureElementSyntaxNode>elements[0];
-          assert.strictEqual(element instanceof ListDestructureElementSyntaxNode, true);
-          assert.strictEqual(element.key, null);
-          assert.strictEqual(element.ampersand, null);
-          assert.strictEqual(element.value instanceof LocalVariableSyntaxNode, true);
+        new ParserTestArgs('$a && 1;', 'should parse a logical and expression', (statements, text) => {
+          let binaryExpr = assertBinaryNode(statements);
+          Test.assertSyntaxToken(binaryExpr.operator, text, TokenKind.BooleanAnd, '&&');
         }),
-        new ParserTestArgs('list($a, $b) = $c;', 'should parse a destructuring assignment with multiple elements', (statements) => {
-          let list = assertListDeconstruction(statements);
-          let elements = list.variables ? list.variables.childNodes() : [];
-          assert.strictEqual(elements.length, 2);
-          let firstElement = <ListDestructureElementSyntaxNode>elements[0];
-          assert.strictEqual(firstElement instanceof ListDestructureElementSyntaxNode, true);
-          assert.strictEqual(firstElement.key, null);
-          assert.strictEqual(firstElement.value instanceof LocalVariableSyntaxNode, true);
-          let secondElement = <ListDestructureElementSyntaxNode>elements[1];
-          assert.strictEqual(secondElement instanceof ListDestructureElementSyntaxNode, true);
-          assert.strictEqual(secondElement.key, null);
-          assert.strictEqual(secondElement.value instanceof LocalVariableSyntaxNode, true);
+        new ParserTestArgs('$a || 1;', 'should parse a logical or expression', (statements, text) => {
+          let binaryExpr = assertBinaryNode(statements);
+          Test.assertSyntaxToken(binaryExpr.operator, text, TokenKind.BooleanOr, '||');
         }),
-        new ParserTestArgs('list($a,) = $c;', 'should parse a destructuring assignment with trailing comma', (statements) => {
-          let list = assertListDeconstruction(statements);
-          let elements = list.variables ? list.variables.childNodes() : [];
-          assert.strictEqual(elements.length, 1);
-          let element = <ListDestructureElementSyntaxNode>elements[0];
-          assert.strictEqual(element instanceof ListDestructureElementSyntaxNode, true);
-          assert.strictEqual(element.key, null);
-          assert.strictEqual(element.value instanceof LocalVariableSyntaxNode, true);
+        new ParserTestArgs('$a and 1;', 'should parse a logical and expression (alternate syntax)', (statements, text) => {
+          let binaryExpr = assertBinaryNode(statements);
+          Test.assertSyntaxToken(binaryExpr.operator, text, TokenKind.LogicalAnd, 'and');
         }),
-        new ParserTestArgs('list(,,$a) = $b;', 'should parse a destructuring assignment with empty leading elements', (statements) => {
-          let list = assertListDeconstruction(statements);
-          let elements = list.variables ? list.variables.childNodes() : [];
-          assert.strictEqual(elements.length, 1);
-          let element = <ListDestructureElementSyntaxNode>elements[0];
-          assert.strictEqual(element instanceof ListDestructureElementSyntaxNode, true);
-          assert.strictEqual(element.key, null);
-          assert.strictEqual(element.value instanceof LocalVariableSyntaxNode, true);
+        new ParserTestArgs('$a or 1;', 'should parse a logical or expression (alternate syntax)', (statements, text) => {
+          let binaryExpr = assertBinaryNode(statements);
+          Test.assertSyntaxToken(binaryExpr.operator, text, TokenKind.LogicalOr, 'or');
         }),
-        new ParserTestArgs('list($a,,) = $b;', 'should parse a destructuring assignment with empty trailing elements', (statements) => {
-          let list = assertListDeconstruction(statements);
-          let elements = list.variables ? list.variables.childNodes() : [];
-          assert.strictEqual(elements.length, 1);
-          let element = <ListDestructureElementSyntaxNode>elements[0];
-          assert.strictEqual(element instanceof ListDestructureElementSyntaxNode, true);
-          assert.strictEqual(element.key, null);
-          assert.strictEqual(element.value instanceof LocalVariableSyntaxNode, true);
-        }),
-        new ParserTestArgs('list(list($a)) = $b;', 'should parse a destructuring assignment with nested deconstruction', (statements) => {
-          let list = assertListDeconstruction(statements);
-          let elements = list.variables ? list.variables.childNodes() : [];
-          assert.strictEqual(elements.length, 1);
-          let element = <ListDestructureElementSyntaxNode>elements[0];
-          assert.strictEqual(element instanceof ListDestructureElementSyntaxNode, true);
-          assert.strictEqual(element.key, null);
-          assert.strictEqual(element.value instanceof ListDestructureSyntaxNode, true);
+        new ParserTestArgs('$a xor 1;', 'should parse a logical xor expression', (statements, text) => {
+          let binaryExpr = assertBinaryNode(statements);
+          Test.assertSyntaxToken(binaryExpr.operator, text, TokenKind.LogicalXor, 'xor');
         }),
       ];
       Test.assertSyntaxNodes(syntaxTests);
-
-      let syntaxTests7_1 = [
-        new ParserTestArgs('list($a => $b) = $c;', 'should parse a destructuring assignment with a key-value pair', (statements) => {
-          let list = assertListDeconstruction(statements);
-          let elements = list.variables ? list.variables.childNodes() : [];
-          assert.strictEqual(elements.length, 1);
-          let element = <ListDestructureElementSyntaxNode>elements[0];
-          assert.strictEqual(element instanceof ListDestructureElementSyntaxNode, true);
-          assert.strictEqual(element.key instanceof LocalVariableSyntaxNode, true);
-          assert.strictEqual(element.ampersand, null);
-          assert.strictEqual(element.value instanceof LocalVariableSyntaxNode, true);
-        }),
-        new ParserTestArgs('list(1 => $a) = $b;', 'should parse a destructuring assignment with a key-value pair (implicit key)', (statements) => {
-          let list = assertListDeconstruction(statements);
-          let elements = list.variables ? list.variables.childNodes() : [];
-          assert.strictEqual(elements.length, 1);
-          let element = <ListDestructureElementSyntaxNode>elements[0];
-          assert.strictEqual(element instanceof ListDestructureElementSyntaxNode, true);
-          assert.strictEqual(element.key instanceof LiteralSyntaxNode, true);
-          assert.strictEqual(element.value instanceof LocalVariableSyntaxNode, true);
-        }),
-      ];
-      Test.assertSyntaxNodes(syntaxTests7_1, PhpVersion.PHP7_1);
-
-      let syntaxTests7_3 = [
-        new ParserTestArgs('list(&$a) = $b;', 'should parse a destructuring assignment (byref value)', (statements) => {
-          let list = assertListDeconstruction(statements);
-          let elements = list.variables ? list.variables.childNodes() : [];
-          assert.strictEqual(elements.length, 1);
-          let element = <ListDestructureElementSyntaxNode>elements[0];
-          assert.strictEqual(element instanceof ListDestructureElementSyntaxNode, true);
-          assert.strictEqual(element.key, null);
-          assert.notStrictEqual(element.ampersand, null);
-          assert.strictEqual(element.value instanceof LocalVariableSyntaxNode, true);
-        }),
-        new ParserTestArgs('list($a => &$b) = $c;', 'should parse a destructuring assignment with a key-value pair (byref value)', (statements) => {
-          let list = assertListDeconstruction(statements);
-          let elements = list.variables ? list.variables.childNodes() : [];
-          assert.strictEqual(elements.length, 1);
-          let element = <ListDestructureElementSyntaxNode>elements[0];
-          assert.strictEqual(element instanceof ListDestructureElementSyntaxNode, true);
-          assert.strictEqual(element.key instanceof LocalVariableSyntaxNode, true);
-          assert.notStrictEqual(element.ampersand, null);
-          assert.strictEqual(element.value instanceof LocalVariableSyntaxNode, true);
-        }),
-      ];
-      Test.assertSyntaxNodes(syntaxTests7_3, PhpVersion.PHP7_3);
-
-      let diagnosticTests = [
-        new DiagnosticTestArgs('list', 'missing open paren', [ErrorCode.ERR_OpenParenExpected], [4]),
-        new DiagnosticTestArgs('list(', 'missing expression', [ErrorCode.ERR_DeconstructVariableMissing], [5]),
-        new DiagnosticTestArgs('list($a', 'missing comma or close paren', [ErrorCode.ERR_CommaOrCloseParenExpected], [7]),
-        new DiagnosticTestArgs('list($a,', 'missing expression or close paren', [ErrorCode.ERR_ExpressionOrCloseParenExpected], [8]),
-        new DiagnosticTestArgs('list($a)', 'missing equals', [ErrorCode.ERR_Syntax], [8]),
-        new DiagnosticTestArgs('list($a) =', 'missing expression (operand)', [ErrorCode.ERR_ExpressionExpectedEOF], [10]),
-
-        new DiagnosticTestArgs('list() = $a;', 'should not parse a destructuring assignment without a variable', [ErrorCode.ERR_DeconstructVariableMissing], [5]),
-        new DiagnosticTestArgs('list(,) = $a;', 'should not parse a destructuring assignment without a variable (with comma)', [ErrorCode.ERR_DeconstructVariableMissing], [6]),
-        new DiagnosticTestArgs('list([$a]) = $b;', 'should not parse a nested deconstruction using mixed syntax', [ErrorCode.ERR_ExpressionNotAddressable], [5]),
-
-        new DiagnosticTestArgs('list(1) = $a;', 'should expect an explicit value', [ErrorCode.ERR_ExpressionNotAddressable], [5]),
-      ];
-      Test.assertDiagnostics(diagnosticTests);
-
-      let diagnosticTestsKeys = [
-        new DiagnosticTestArgs('list($a => 1) = $b;', 'should expect an explicit value in key-value pair', [ErrorCode.ERR_FeatureListDeconstructionKeys, ErrorCode.ERR_ExpressionNotAddressable], [8, 11]),
-        new DiagnosticTestArgs('list($a => &1) = $c;', 'should expect an explicit value in key-value pair with byref value', [ErrorCode.ERR_FeatureListDeconstructionKeys, ErrorCode.ERR_FeatureListDeconstructionByRef, ErrorCode.ERR_ExpressionNotAddressable], [8, 11, 12]),
-        new DiagnosticTestArgs('list($a => &list($b)) = $c;', 'should not parse a nested deconstruction as a byref value', [ErrorCode.ERR_FeatureListDeconstructionKeys, ErrorCode.ERR_FeatureListDeconstructionByRef, ErrorCode.ERR_Syntax], [8, 11, 20]),
-      ];
-      Test.assertDiagnostics(diagnosticTestsKeys, PhpVersion.PHP7_0, PhpVersion.PHP7_0);
-
-      let diagnosticTestsByRef = [
-        new DiagnosticTestArgs('list(&$a => $b) = $c;', 'should not parse a destructuring assignment containing a byref key', [ErrorCode.ERR_FeatureListDeconstructionByRef, ErrorCode.ERR_CommaOrCloseParenExpected], [5, 8]),
-      ];
-      Test.assertDiagnostics(diagnosticTestsByRef, PhpVersion.PHP7_0, PhpVersion.PHP7_2);
     });
 
-    describe('destructuring-assignment-expression (short-syntax)', function() {
-      // Since the LHS of this expression is parsed as an array initializer,
-      // tests for array elements is handled there.
+    describe('multiplicative-expression', function() {
       let syntaxTests = [
-        new ParserTestArgs('[$a] = $b;', 'should parse a destructuring assignment', (statements) => {
-          let array = assertArrayDeconstruction(statements);
-          let elements = array.initializerList ? array.initializerList.childNodes() : [];
-          assert.strictEqual(elements.length, 1);
-          assert.strictEqual(elements[0] instanceof ArrayElementSyntaxNode, true);
+        new ParserTestArgs('$a * 2;', 'should parse a multiply expression', (statements, text) => {
+          let binaryExpr = assertBinaryNode(statements);
+          Test.assertSyntaxToken(binaryExpr.operator, text, TokenKind.Asterisk, '*');
         }),
-        new ParserTestArgs('[&$a] = $b;', 'should parse a destructuring assignment with byref value', (statements) => {
-          let array = assertArrayDeconstruction(statements);
-          let elements = array.initializerList ? array.initializerList.childNodes() : [];
-          assert.strictEqual(elements.length, 1);
-          assert.strictEqual(elements[0] instanceof ArrayElementSyntaxNode, true);
+        new ParserTestArgs('$a / 2;', 'should parse a divide expression', (statements, text) => {
+          let binaryExpr = assertBinaryNode(statements);
+          Test.assertSyntaxToken(binaryExpr.operator, text, TokenKind.Slash, '/');
         }),
-        new ParserTestArgs('[$a, $b] = $c;', 'should parse a destructuring assignment with multiple elements', (statements) => {
-          let array = assertArrayDeconstruction(statements);
-          let elements = array.initializerList ? array.initializerList.childNodes() : [];
-          assert.strictEqual(elements.length, 2);
-          assert.strictEqual(elements[0] instanceof ArrayElementSyntaxNode, true);
-          assert.strictEqual(elements[1] instanceof ArrayElementSyntaxNode, true);
-        }),
-        new ParserTestArgs('[,$a] = $c;', 'should parse a destructuring assignment with leading comma', (statements) => {
-          let array = assertArrayDeconstruction(statements);
-          let elements = array.initializerList ? array.initializerList.childNodes() : [];
-          assert.strictEqual(elements.length, 1);
-          assert.strictEqual(elements[0] instanceof ArrayElementSyntaxNode, true);
-        }),
-        new ParserTestArgs('[$a,] = $c;', 'should parse a destructuring assignment with trailing comma', (statements) => {
-          let array = assertArrayDeconstruction(statements);
-          let elements = array.initializerList ? array.initializerList.childNodes() : [];
-          assert.strictEqual(elements.length, 1);
-          assert.strictEqual(elements[0] instanceof ArrayElementSyntaxNode, true);
-        }),
-        new ParserTestArgs('[,,$a] = $b;', 'should parse a destructuring assignment with empty leading elements', (statements) => {
-          let array = assertArrayDeconstruction(statements);
-          let elements = array.initializerList ? array.initializerList.childNodes() : [];
-          assert.strictEqual(elements.length, 1);
-          assert.strictEqual(elements[0] instanceof ArrayElementSyntaxNode, true);
-        }),
-        new ParserTestArgs('[$a,,] = $b;', 'should parse a destructuring assignment with empty trailing elements', (statements) => {
-          let array = assertArrayDeconstruction(statements);
-          let elements = array.initializerList ? array.initializerList.childNodes() : [];
-          assert.strictEqual(elements.length, 1);
-          assert.strictEqual(elements[0] instanceof ArrayElementSyntaxNode, true);
-        }),
-        new ParserTestArgs('[[$a]] = $b;', 'should parse a destructuring assignment with nested deconstruction', (statements) => {
-          let array = assertArrayDeconstruction(statements);
-          let elements = array.initializerList ? array.initializerList.childNodes() : [];
-          assert.strictEqual(elements.length, 1);
-          assert.strictEqual(elements[0] instanceof ArrayElementSyntaxNode, true);
-        }),
-        new ParserTestArgs('[$a => $b] = $c;', 'should parse a destructuring assignment with a key-value pair', (statements) => {
-          let array = assertArrayDeconstruction(statements);
-          let elements = array.initializerList ? array.initializerList.childNodes() : [];
-          assert.strictEqual(elements.length, 1);
-          assert.strictEqual(elements[0] instanceof ArrayElementSyntaxNode, true);
-        }),
-        new ParserTestArgs('[$a => &$b] = $c;', 'should parse a destructuring assignment with a key-value pair (byref value)', (statements) => {
-          let array = assertArrayDeconstruction(statements);
-          let elements = array.initializerList ? array.initializerList.childNodes() : [];
-          assert.strictEqual(elements.length, 1);
-          assert.strictEqual(elements[0] instanceof ArrayElementSyntaxNode, true);
-        }),
-        new ParserTestArgs('[1 => $a] = $b;', 'should parse a destructuring assignment with a key-value pair (implicit key)', (statements) => {
-          let array = assertArrayDeconstruction(statements);
-          let elements = array.initializerList ? array.initializerList.childNodes() : [];
-          assert.strictEqual(elements.length, 1);
-          assert.strictEqual(elements[0] instanceof ArrayElementSyntaxNode, true);
-        }),
-      ];
-      Test.assertSyntaxNodes(syntaxTests, PhpVersion.PHP7_1);
-
-      let diagnosticTests = [
-        new DiagnosticTestArgs('[$a] =', 'missing expression (operand)', [ErrorCode.ERR_FeatureListDeconstructionShortSyntax, ErrorCode.ERR_ExpressionExpectedEOF], [0, 6]),
-      ];
-      Test.assertDiagnostics(diagnosticTests, PhpVersion.PHP7_0, PhpVersion.PHP7_0);
-    });
-
-    describe('compound-assignment-expression', function() {
-      let syntaxTests = [
-        new ParserTestArgs('$a **= 2;', 'should parse a pow equals expression', (statements, text) => {
-          let assignment = assertAssignmentNode(statements);
-          Test.assertSyntaxToken(assignment.operator, text, TokenKind.PowEqual, '**=');
-        }),
-        new ParserTestArgs('$a *= 2;', 'should parse a multiply equals expression', (statements, text) => {
-          let assignment = assertAssignmentNode(statements);
-          Test.assertSyntaxToken(assignment.operator, text, TokenKind.MultiplyEqual, '*=');
-        }),
-        new ParserTestArgs('$a /= 2;', 'should parse a divide equals expression', (statements, text) => {
-          let assignment = assertAssignmentNode(statements);
-          Test.assertSyntaxToken(assignment.operator, text, TokenKind.DivideEqual, '/=');
-        }),
-        new ParserTestArgs('$a %= 2;', 'should parse a modulus equals expression', (statements, text) => {
-          let assignment = assertAssignmentNode(statements);
-          Test.assertSyntaxToken(assignment.operator, text, TokenKind.ModEqual, '%=');
-        }),
-        new ParserTestArgs('$a += 2;', 'should parse a plus equals expression', (statements, text) => {
-          let assignment = assertAssignmentNode(statements);
-          Test.assertSyntaxToken(assignment.operator, text, TokenKind.PlusEqual, '+=');
-        }),
-        new ParserTestArgs('$a -= 2;', 'should parse a subtract equals expression', (statements, text) => {
-          let assignment = assertAssignmentNode(statements);
-          Test.assertSyntaxToken(assignment.operator, text, TokenKind.MinusEqual, '-=');
-        }),
-        new ParserTestArgs('$a .= "";', 'should parse a concat equals expression', (statements, text) => {
-          let assignment = assertAssignmentNode(statements);
-          Test.assertSyntaxToken(assignment.operator, text, TokenKind.ConcatEqual, '.=');
-        }),
-        new ParserTestArgs('$a <<= 2;', 'should parse a shift left equals expression', (statements, text) => {
-          let assignment = assertAssignmentNode(statements);
-          Test.assertSyntaxToken(assignment.operator, text, TokenKind.ShiftLeftEqual, '<<=');
-        }),
-        new ParserTestArgs('$a >>= 2;', 'should parse a shift right equals expression', (statements, text) => {
-          let assignment = assertAssignmentNode(statements);
-          Test.assertSyntaxToken(assignment.operator, text, TokenKind.ShiftRightEqual, '>>=');
-        }),
-        new ParserTestArgs('$a &= 2;', 'should parse a bitwise and equals expression', (statements, text) => {
-          let assignment = assertAssignmentNode(statements);
-          Test.assertSyntaxToken(assignment.operator, text, TokenKind.AndEqual, '&=');
-        }),
-        new ParserTestArgs('$a ^= 2;', 'should parse a bitwise xor equals expression', (statements, text) => {
-          let assignment = assertAssignmentNode(statements);
-          Test.assertSyntaxToken(assignment.operator, text, TokenKind.XorEqual, '^=');
-        }),
-        new ParserTestArgs('$a |= 2;', 'should parse a bitwise or equals expression', (statements, text) => {
-          let assignment = assertAssignmentNode(statements);
-          Test.assertSyntaxToken(assignment.operator, text, TokenKind.OrEqual, '|=');
+        new ParserTestArgs('$a % 2;', 'should parse a modulus expression', (statements, text) => {
+          let binaryExpr = assertBinaryNode(statements);
+          Test.assertSyntaxToken(binaryExpr.operator, text, TokenKind.Percent, '%');
         }),
       ];
       Test.assertSyntaxNodes(syntaxTests);
+    });
 
-      let syntaxTests7_4 = [
-        new ParserTestArgs('$a ??= 2;', 'should parse a coalesce equals expression', (statements, text) => {
-          let assignment = assertAssignmentNode(statements);
-          Test.assertSyntaxToken(assignment.operator, text, TokenKind.CoalesceEqual, '??=');
+    describe('relational-expression', function() {
+      let syntaxTests = [
+        new ParserTestArgs('$a < 1;', 'should parse a less than expression', (statements, text) => {
+          let binaryExpr = assertBinaryNode(statements);
+          Test.assertSyntaxToken(binaryExpr.operator, text, TokenKind.LessThan, '<');
+        }),
+        new ParserTestArgs('$a > 1;', 'should parse a greater than expression', (statements, text) => {
+          let binaryExpr = assertBinaryNode(statements);
+          Test.assertSyntaxToken(binaryExpr.operator, text, TokenKind.GreaterThan, '>');
+        }),
+        new ParserTestArgs('$a <= 1;', 'should parse a less than or equal expression', (statements, text) => {
+          let binaryExpr = assertBinaryNode(statements);
+          Test.assertSyntaxToken(binaryExpr.operator, text, TokenKind.IsLessThanOrEqual, '<=');
+        }),
+        new ParserTestArgs('$a >= 1;', 'should parse a greater than or equal expression', (statements, text) => {
+          let binaryExpr = assertBinaryNode(statements);
+          Test.assertSyntaxToken(binaryExpr.operator, text, TokenKind.IsGreaterThanOrEqual, '>=');
+        }),
+        new ParserTestArgs('$a <=> 1;', 'should parse a spaceship expression', (statements, text) => {
+          let binaryExpr = assertBinaryNode(statements);
+          Test.assertSyntaxToken(binaryExpr.operator, text, TokenKind.Spaceship, '<=>');
         }),
       ];
-      Test.assertSyntaxNodes(syntaxTests7_4, PhpVersion.PHP7_4);
+      Test.assertSyntaxNodes(syntaxTests);
+    });
+
+    describe('shift-expression', function() {
+      let syntaxTests = [
+        new ParserTestArgs('$a << 1;', 'should parse a left shift expression', (statements, text) => {
+          let binaryExpr = assertBinaryNode(statements);
+          Test.assertSyntaxToken(binaryExpr.operator, text, TokenKind.ShiftLeft, '<<');
+        }),
+        new ParserTestArgs('$a >> 1;', 'should parse a right shift expression', (statements, text) => {
+          let binaryExpr = assertBinaryNode(statements);
+          Test.assertSyntaxToken(binaryExpr.operator, text, TokenKind.ShiftRight, '>>');
+        }),
+      ];
+      Test.assertSyntaxNodes(syntaxTests);
+    });
+
+    describe('assignment expressions', function() {
+
+      describe('assignment-expression', function() {
+        let syntaxTests = [
+          new ParserTestArgs('$a = 1;', 'should parse an assignment expression', (statements) => {
+            let exprNode = <ExpressionStatementSyntaxNode>statements[0];
+            assert.strictEqual(exprNode instanceof ExpressionStatementSyntaxNode, true, 'ExpressionStatementSyntaxNode');
+            let assignmentNode = <AssignmentSyntaxNode>exprNode.expression;
+            assert.strictEqual(assignmentNode instanceof AssignmentSyntaxNode, true);
+            assert.strictEqual(assignmentNode.leftOperand instanceof LocalVariableSyntaxNode, true);
+            assert.strictEqual(assignmentNode.ampersand, null);
+            assert.strictEqual(assignmentNode.rightOperand instanceof LiteralSyntaxNode, true);
+          }),
+          new ParserTestArgs('$a =& $b;', 'should parse a byref assignment expression', (statements) => {
+            let exprNode = <ExpressionStatementSyntaxNode>statements[0];
+            assert.strictEqual(exprNode instanceof ExpressionStatementSyntaxNode, true, 'ExpressionStatementSyntaxNode');
+            let assignmentNode = <AssignmentSyntaxNode>exprNode.expression;
+            assert.strictEqual(assignmentNode instanceof AssignmentSyntaxNode, true);
+            assert.strictEqual(assignmentNode.leftOperand instanceof LocalVariableSyntaxNode, true);
+            assert.notStrictEqual(assignmentNode.ampersand, null);
+            assert.strictEqual(assignmentNode.rightOperand instanceof LocalVariableSyntaxNode, true);
+          }),
+          // Expected: !($a = 1)
+          new ParserTestArgs('!$a = 1;', 'should parse lhs of assignment as explicit expression (unary)', (statements) => {
+            let exprNode = <ExpressionStatementSyntaxNode>statements[0];
+            assert.strictEqual(exprNode instanceof ExpressionStatementSyntaxNode, true, 'ExpressionStatementSyntaxNode');
+            let parentNode = <UnarySyntaxNode>exprNode.expression;
+            assert.strictEqual(parentNode instanceof UnarySyntaxNode, true, 'UnarySyntaxNode');
+            let childNode = <AssignmentSyntaxNode>parentNode.operand;
+            assert.strictEqual(childNode instanceof AssignmentSyntaxNode, true, 'AssignmentSyntaxNode');
+            assert.strictEqual(childNode.leftOperand instanceof LocalVariableSyntaxNode, true);
+          }),
+          // Expected: $a == ($b = 1)
+          new ParserTestArgs('$a == $b = 1;', 'should parse lhs of assignment as explicit expression (binary)', (statements) => {
+            let exprNode = <ExpressionStatementSyntaxNode>statements[0];
+            assert.strictEqual(exprNode instanceof ExpressionStatementSyntaxNode, true, 'ExpressionStatementSyntaxNode');
+            let binaryNode = <BinarySyntaxNode>exprNode.expression;
+            assert.strictEqual(binaryNode instanceof BinarySyntaxNode, true, 'BinarySyntaxNode');
+            let assignmentNode = <AssignmentSyntaxNode>binaryNode.rightOperand;
+            assert.strictEqual(assignmentNode instanceof AssignmentSyntaxNode, true, 'AssignmentSyntaxNode');
+            assert.strictEqual(assignmentNode.leftOperand instanceof LocalVariableSyntaxNode, true);
+          }),
+          new ParserTestArgs('$a =& $b + $c;', 'should parse rhs of byref assignment as explicit expression', (statements) => {
+            let exprNode = <ExpressionStatementSyntaxNode>statements[0];
+            assert.strictEqual(exprNode instanceof ExpressionStatementSyntaxNode, true, 'ExpressionStatementSyntaxNode');
+            let binaryNode = <BinarySyntaxNode>exprNode.expression;
+            assert.strictEqual(binaryNode instanceof BinarySyntaxNode, true, 'BinarySyntaxNode');
+            assert.strictEqual(binaryNode.rightOperand instanceof LocalVariableSyntaxNode, true);
+            let assignmentNode = <AssignmentSyntaxNode>binaryNode.leftOperand;
+            assert.strictEqual(assignmentNode instanceof AssignmentSyntaxNode, true, 'AssignmentSyntaxNode');
+            assert.strictEqual(assignmentNode.leftOperand instanceof LocalVariableSyntaxNode, true);
+            assert.strictEqual(assignmentNode.rightOperand instanceof LocalVariableSyntaxNode, true);
+          }),
+        ];
+        Test.assertSyntaxNodes(syntaxTests);
+
+        let diagnosticTests = [
+          new DiagnosticTestArgs('$a =& 1;', 'should expect explicit expression in rhs of byref assignment', [ErrorCode.ERR_ExpressionNotAddressable], [6]),
+        ];
+        Test.assertDiagnostics(diagnosticTests);
+      });
+
+      describe('compound-assignment-expression', function() {
+        let syntaxTests = [
+          new ParserTestArgs('$a **= 2;', 'should parse a pow equals expression', (statements, text) => {
+            let assignment = assertAssignmentNode(statements);
+            Test.assertSyntaxToken(assignment.operator, text, TokenKind.PowEqual, '**=');
+          }),
+          new ParserTestArgs('$a *= 2;', 'should parse a multiply equals expression', (statements, text) => {
+            let assignment = assertAssignmentNode(statements);
+            Test.assertSyntaxToken(assignment.operator, text, TokenKind.MultiplyEqual, '*=');
+          }),
+          new ParserTestArgs('$a /= 2;', 'should parse a divide equals expression', (statements, text) => {
+            let assignment = assertAssignmentNode(statements);
+            Test.assertSyntaxToken(assignment.operator, text, TokenKind.DivideEqual, '/=');
+          }),
+          new ParserTestArgs('$a %= 2;', 'should parse a modulus equals expression', (statements, text) => {
+            let assignment = assertAssignmentNode(statements);
+            Test.assertSyntaxToken(assignment.operator, text, TokenKind.ModEqual, '%=');
+          }),
+          new ParserTestArgs('$a += 2;', 'should parse a plus equals expression', (statements, text) => {
+            let assignment = assertAssignmentNode(statements);
+            Test.assertSyntaxToken(assignment.operator, text, TokenKind.PlusEqual, '+=');
+          }),
+          new ParserTestArgs('$a -= 2;', 'should parse a subtract equals expression', (statements, text) => {
+            let assignment = assertAssignmentNode(statements);
+            Test.assertSyntaxToken(assignment.operator, text, TokenKind.MinusEqual, '-=');
+          }),
+          new ParserTestArgs('$a .= "";', 'should parse a concat equals expression', (statements, text) => {
+            let assignment = assertAssignmentNode(statements);
+            Test.assertSyntaxToken(assignment.operator, text, TokenKind.ConcatEqual, '.=');
+          }),
+          new ParserTestArgs('$a <<= 2;', 'should parse a shift left equals expression', (statements, text) => {
+            let assignment = assertAssignmentNode(statements);
+            Test.assertSyntaxToken(assignment.operator, text, TokenKind.ShiftLeftEqual, '<<=');
+          }),
+          new ParserTestArgs('$a >>= 2;', 'should parse a shift right equals expression', (statements, text) => {
+            let assignment = assertAssignmentNode(statements);
+            Test.assertSyntaxToken(assignment.operator, text, TokenKind.ShiftRightEqual, '>>=');
+          }),
+          new ParserTestArgs('$a &= 2;', 'should parse a bitwise and equals expression', (statements, text) => {
+            let assignment = assertAssignmentNode(statements);
+            Test.assertSyntaxToken(assignment.operator, text, TokenKind.AndEqual, '&=');
+          }),
+          new ParserTestArgs('$a ^= 2;', 'should parse a bitwise xor equals expression', (statements, text) => {
+            let assignment = assertAssignmentNode(statements);
+            Test.assertSyntaxToken(assignment.operator, text, TokenKind.XorEqual, '^=');
+          }),
+          new ParserTestArgs('$a |= 2;', 'should parse a bitwise or equals expression', (statements, text) => {
+            let assignment = assertAssignmentNode(statements);
+            Test.assertSyntaxToken(assignment.operator, text, TokenKind.OrEqual, '|=');
+          }),
+        ];
+        Test.assertSyntaxNodes(syntaxTests);
+
+        let syntaxTests7_4 = [
+          new ParserTestArgs('$a ??= 2;', 'should parse a coalesce equals expression', (statements, text) => {
+            let assignment = assertAssignmentNode(statements);
+            Test.assertSyntaxToken(assignment.operator, text, TokenKind.CoalesceEqual, '??=');
+          }),
+        ];
+        Test.assertSyntaxNodes(syntaxTests7_4, PhpVersion.PHP7_4);
+      });
+
+      describe('destructuring-assignment-expression', function() {
+        let syntaxTests = [
+          new ParserTestArgs('list($a) = $b;', 'should parse a destructuring assignment', (statements) => {
+            let list = assertListDeconstruction(statements);
+            let elements = list.variables ? list.variables.childNodes() : [];
+            assert.strictEqual(elements.length, 1);
+            let element = <ListDestructureElementSyntaxNode>elements[0];
+            assert.strictEqual(element instanceof ListDestructureElementSyntaxNode, true);
+            assert.strictEqual(element.key, null);
+            assert.strictEqual(element.ampersand, null);
+            assert.strictEqual(element.value instanceof LocalVariableSyntaxNode, true);
+          }),
+          new ParserTestArgs('list($a, $b) = $c;', 'should parse a destructuring assignment with multiple elements', (statements) => {
+            let list = assertListDeconstruction(statements);
+            let elements = list.variables ? list.variables.childNodes() : [];
+            assert.strictEqual(elements.length, 2);
+            let firstElement = <ListDestructureElementSyntaxNode>elements[0];
+            assert.strictEqual(firstElement instanceof ListDestructureElementSyntaxNode, true);
+            assert.strictEqual(firstElement.key, null);
+            assert.strictEqual(firstElement.value instanceof LocalVariableSyntaxNode, true);
+            let secondElement = <ListDestructureElementSyntaxNode>elements[1];
+            assert.strictEqual(secondElement instanceof ListDestructureElementSyntaxNode, true);
+            assert.strictEqual(secondElement.key, null);
+            assert.strictEqual(secondElement.value instanceof LocalVariableSyntaxNode, true);
+          }),
+          new ParserTestArgs('list($a,) = $c;', 'should parse a destructuring assignment with trailing comma', (statements) => {
+            let list = assertListDeconstruction(statements);
+            let elements = list.variables ? list.variables.childNodes() : [];
+            assert.strictEqual(elements.length, 1);
+            let element = <ListDestructureElementSyntaxNode>elements[0];
+            assert.strictEqual(element instanceof ListDestructureElementSyntaxNode, true);
+            assert.strictEqual(element.key, null);
+            assert.strictEqual(element.value instanceof LocalVariableSyntaxNode, true);
+          }),
+          new ParserTestArgs('list(,,$a) = $b;', 'should parse a destructuring assignment with empty leading elements', (statements) => {
+            let list = assertListDeconstruction(statements);
+            let elements = list.variables ? list.variables.childNodes() : [];
+            assert.strictEqual(elements.length, 1);
+            let element = <ListDestructureElementSyntaxNode>elements[0];
+            assert.strictEqual(element instanceof ListDestructureElementSyntaxNode, true);
+            assert.strictEqual(element.key, null);
+            assert.strictEqual(element.value instanceof LocalVariableSyntaxNode, true);
+          }),
+          new ParserTestArgs('list($a,,) = $b;', 'should parse a destructuring assignment with empty trailing elements', (statements) => {
+            let list = assertListDeconstruction(statements);
+            let elements = list.variables ? list.variables.childNodes() : [];
+            assert.strictEqual(elements.length, 1);
+            let element = <ListDestructureElementSyntaxNode>elements[0];
+            assert.strictEqual(element instanceof ListDestructureElementSyntaxNode, true);
+            assert.strictEqual(element.key, null);
+            assert.strictEqual(element.value instanceof LocalVariableSyntaxNode, true);
+          }),
+          new ParserTestArgs('list(list($a)) = $b;', 'should parse a destructuring assignment with nested deconstruction', (statements) => {
+            let list = assertListDeconstruction(statements);
+            let elements = list.variables ? list.variables.childNodes() : [];
+            assert.strictEqual(elements.length, 1);
+            let element = <ListDestructureElementSyntaxNode>elements[0];
+            assert.strictEqual(element instanceof ListDestructureElementSyntaxNode, true);
+            assert.strictEqual(element.key, null);
+            assert.strictEqual(element.value instanceof ListDestructureSyntaxNode, true);
+          }),
+        ];
+        Test.assertSyntaxNodes(syntaxTests);
+
+        let syntaxTests7_1 = [
+          new ParserTestArgs('list($a => $b) = $c;', 'should parse a destructuring assignment with a key-value pair', (statements) => {
+            let list = assertListDeconstruction(statements);
+            let elements = list.variables ? list.variables.childNodes() : [];
+            assert.strictEqual(elements.length, 1);
+            let element = <ListDestructureElementSyntaxNode>elements[0];
+            assert.strictEqual(element instanceof ListDestructureElementSyntaxNode, true);
+            assert.strictEqual(element.key instanceof LocalVariableSyntaxNode, true);
+            assert.strictEqual(element.ampersand, null);
+            assert.strictEqual(element.value instanceof LocalVariableSyntaxNode, true);
+          }),
+          new ParserTestArgs('list(1 => $a) = $b;', 'should parse a destructuring assignment with a key-value pair (implicit key)', (statements) => {
+            let list = assertListDeconstruction(statements);
+            let elements = list.variables ? list.variables.childNodes() : [];
+            assert.strictEqual(elements.length, 1);
+            let element = <ListDestructureElementSyntaxNode>elements[0];
+            assert.strictEqual(element instanceof ListDestructureElementSyntaxNode, true);
+            assert.strictEqual(element.key instanceof LiteralSyntaxNode, true);
+            assert.strictEqual(element.value instanceof LocalVariableSyntaxNode, true);
+          }),
+        ];
+        Test.assertSyntaxNodes(syntaxTests7_1, PhpVersion.PHP7_1);
+
+        let syntaxTests7_3 = [
+          new ParserTestArgs('list(&$a) = $b;', 'should parse a destructuring assignment (byref value)', (statements) => {
+            let list = assertListDeconstruction(statements);
+            let elements = list.variables ? list.variables.childNodes() : [];
+            assert.strictEqual(elements.length, 1);
+            let element = <ListDestructureElementSyntaxNode>elements[0];
+            assert.strictEqual(element instanceof ListDestructureElementSyntaxNode, true);
+            assert.strictEqual(element.key, null);
+            assert.notStrictEqual(element.ampersand, null);
+            assert.strictEqual(element.value instanceof LocalVariableSyntaxNode, true);
+          }),
+          new ParserTestArgs('list($a => &$b) = $c;', 'should parse a destructuring assignment with a key-value pair (byref value)', (statements) => {
+            let list = assertListDeconstruction(statements);
+            let elements = list.variables ? list.variables.childNodes() : [];
+            assert.strictEqual(elements.length, 1);
+            let element = <ListDestructureElementSyntaxNode>elements[0];
+            assert.strictEqual(element instanceof ListDestructureElementSyntaxNode, true);
+            assert.strictEqual(element.key instanceof LocalVariableSyntaxNode, true);
+            assert.notStrictEqual(element.ampersand, null);
+            assert.strictEqual(element.value instanceof LocalVariableSyntaxNode, true);
+          }),
+        ];
+        Test.assertSyntaxNodes(syntaxTests7_3, PhpVersion.PHP7_3);
+
+        let diagnosticTests = [
+          new DiagnosticTestArgs('list', 'missing open paren', [ErrorCode.ERR_OpenParenExpected], [4]),
+          new DiagnosticTestArgs('list(', 'missing expression', [ErrorCode.ERR_DeconstructVariableMissing], [5]),
+          new DiagnosticTestArgs('list($a', 'missing comma or close paren', [ErrorCode.ERR_CommaOrCloseParenExpected], [7]),
+          new DiagnosticTestArgs('list($a,', 'missing expression or close paren', [ErrorCode.ERR_ExpressionOrCloseParenExpected], [8]),
+          new DiagnosticTestArgs('list($a)', 'missing equals', [ErrorCode.ERR_Syntax], [8]),
+          new DiagnosticTestArgs('list($a) =', 'missing expression (operand)', [ErrorCode.ERR_ExpressionExpectedEOF], [10]),
+
+          new DiagnosticTestArgs('list() = $a;', 'should not parse a destructuring assignment without a variable', [ErrorCode.ERR_DeconstructVariableMissing], [5]),
+          new DiagnosticTestArgs('list(,) = $a;', 'should not parse a destructuring assignment without a variable (with comma)', [ErrorCode.ERR_DeconstructVariableMissing], [6]),
+          new DiagnosticTestArgs('list([$a]) = $b;', 'should not parse a nested deconstruction using mixed syntax', [ErrorCode.ERR_ExpressionNotAddressable], [5]),
+
+          new DiagnosticTestArgs('list(1) = $a;', 'should expect an explicit value', [ErrorCode.ERR_ExpressionNotAddressable], [5]),
+        ];
+        Test.assertDiagnostics(diagnosticTests);
+
+        let diagnosticTestsKeys = [
+          new DiagnosticTestArgs('list($a => 1) = $b;', 'should expect an explicit value in key-value pair', [ErrorCode.ERR_FeatureListDeconstructionKeys, ErrorCode.ERR_ExpressionNotAddressable], [8, 11]),
+          new DiagnosticTestArgs('list($a => &1) = $c;', 'should expect an explicit value in key-value pair with byref value', [ErrorCode.ERR_FeatureListDeconstructionKeys, ErrorCode.ERR_FeatureListDeconstructionByRef, ErrorCode.ERR_ExpressionNotAddressable], [8, 11, 12]),
+          new DiagnosticTestArgs('list($a => &list($b)) = $c;', 'should not parse a nested deconstruction as a byref value', [ErrorCode.ERR_FeatureListDeconstructionKeys, ErrorCode.ERR_FeatureListDeconstructionByRef, ErrorCode.ERR_Syntax], [8, 11, 20]),
+        ];
+        Test.assertDiagnostics(diagnosticTestsKeys, PhpVersion.PHP7_0, PhpVersion.PHP7_0);
+
+        let diagnosticTestsByRef = [
+          new DiagnosticTestArgs('list(&$a => $b) = $c;', 'should not parse a destructuring assignment containing a byref key', [ErrorCode.ERR_FeatureListDeconstructionByRef, ErrorCode.ERR_CommaOrCloseParenExpected], [5, 8]),
+        ];
+        Test.assertDiagnostics(diagnosticTestsByRef, PhpVersion.PHP7_0, PhpVersion.PHP7_2);
+      });
+
+      describe('destructuring-assignment-expression (short-syntax)', function() {
+        // Since the LHS of this expression is parsed as an array initializer,
+        // tests for array elements is handled there.
+        let syntaxTests = [
+          new ParserTestArgs('[$a] = $b;', 'should parse a destructuring assignment', (statements) => {
+            let array = assertArrayDeconstruction(statements);
+            let elements = array.initializerList ? array.initializerList.childNodes() : [];
+            assert.strictEqual(elements.length, 1);
+            assert.strictEqual(elements[0] instanceof ArrayElementSyntaxNode, true);
+          }),
+          new ParserTestArgs('[&$a] = $b;', 'should parse a destructuring assignment with byref value', (statements) => {
+            let array = assertArrayDeconstruction(statements);
+            let elements = array.initializerList ? array.initializerList.childNodes() : [];
+            assert.strictEqual(elements.length, 1);
+            assert.strictEqual(elements[0] instanceof ArrayElementSyntaxNode, true);
+          }),
+          new ParserTestArgs('[$a, $b] = $c;', 'should parse a destructuring assignment with multiple elements', (statements) => {
+            let array = assertArrayDeconstruction(statements);
+            let elements = array.initializerList ? array.initializerList.childNodes() : [];
+            assert.strictEqual(elements.length, 2);
+            assert.strictEqual(elements[0] instanceof ArrayElementSyntaxNode, true);
+            assert.strictEqual(elements[1] instanceof ArrayElementSyntaxNode, true);
+          }),
+          new ParserTestArgs('[,$a] = $c;', 'should parse a destructuring assignment with leading comma', (statements) => {
+            let array = assertArrayDeconstruction(statements);
+            let elements = array.initializerList ? array.initializerList.childNodes() : [];
+            assert.strictEqual(elements.length, 1);
+            assert.strictEqual(elements[0] instanceof ArrayElementSyntaxNode, true);
+          }),
+          new ParserTestArgs('[$a,] = $c;', 'should parse a destructuring assignment with trailing comma', (statements) => {
+            let array = assertArrayDeconstruction(statements);
+            let elements = array.initializerList ? array.initializerList.childNodes() : [];
+            assert.strictEqual(elements.length, 1);
+            assert.strictEqual(elements[0] instanceof ArrayElementSyntaxNode, true);
+          }),
+          new ParserTestArgs('[,,$a] = $b;', 'should parse a destructuring assignment with empty leading elements', (statements) => {
+            let array = assertArrayDeconstruction(statements);
+            let elements = array.initializerList ? array.initializerList.childNodes() : [];
+            assert.strictEqual(elements.length, 1);
+            assert.strictEqual(elements[0] instanceof ArrayElementSyntaxNode, true);
+          }),
+          new ParserTestArgs('[$a,,] = $b;', 'should parse a destructuring assignment with empty trailing elements', (statements) => {
+            let array = assertArrayDeconstruction(statements);
+            let elements = array.initializerList ? array.initializerList.childNodes() : [];
+            assert.strictEqual(elements.length, 1);
+            assert.strictEqual(elements[0] instanceof ArrayElementSyntaxNode, true);
+          }),
+          new ParserTestArgs('[[$a]] = $b;', 'should parse a destructuring assignment with nested deconstruction', (statements) => {
+            let array = assertArrayDeconstruction(statements);
+            let elements = array.initializerList ? array.initializerList.childNodes() : [];
+            assert.strictEqual(elements.length, 1);
+            assert.strictEqual(elements[0] instanceof ArrayElementSyntaxNode, true);
+          }),
+          new ParserTestArgs('[$a => $b] = $c;', 'should parse a destructuring assignment with a key-value pair', (statements) => {
+            let array = assertArrayDeconstruction(statements);
+            let elements = array.initializerList ? array.initializerList.childNodes() : [];
+            assert.strictEqual(elements.length, 1);
+            assert.strictEqual(elements[0] instanceof ArrayElementSyntaxNode, true);
+          }),
+          new ParserTestArgs('[$a => &$b] = $c;', 'should parse a destructuring assignment with a key-value pair (byref value)', (statements) => {
+            let array = assertArrayDeconstruction(statements);
+            let elements = array.initializerList ? array.initializerList.childNodes() : [];
+            assert.strictEqual(elements.length, 1);
+            assert.strictEqual(elements[0] instanceof ArrayElementSyntaxNode, true);
+          }),
+          new ParserTestArgs('[1 => $a] = $b;', 'should parse a destructuring assignment with a key-value pair (implicit key)', (statements) => {
+            let array = assertArrayDeconstruction(statements);
+            let elements = array.initializerList ? array.initializerList.childNodes() : [];
+            assert.strictEqual(elements.length, 1);
+            assert.strictEqual(elements[0] instanceof ArrayElementSyntaxNode, true);
+          }),
+        ];
+        Test.assertSyntaxNodes(syntaxTests, PhpVersion.PHP7_1);
+
+        let diagnosticTests = [
+          new DiagnosticTestArgs('[$a] =', 'missing expression (operand)', [ErrorCode.ERR_FeatureListDeconstructionShortSyntax, ErrorCode.ERR_ExpressionExpectedEOF], [0, 6]),
+        ];
+        Test.assertDiagnostics(diagnosticTests, PhpVersion.PHP7_0, PhpVersion.PHP7_0);
+      });
+
     });
 
   });

--- a/test/src/parser/PhpParserTest_Expressions_Postfix.ts
+++ b/test/src/parser/PhpParserTest_Expressions_Postfix.ts
@@ -253,7 +253,7 @@ describe('PhpParser', function() {
     });
 
     describe('element-access-expression (alternate syntax)', function() {
-      let syntaxTests = [
+      let syntaxRegressionTests8_0 = [
         // Variables.
         new ParserTestArgs('$a{0};', 'element access of a variable', (statements) => {
           let accessNode = assertElementAccess(statements, true);
@@ -321,7 +321,7 @@ describe('PhpParser', function() {
           assert.strictEqual(accessNode.dereferencable instanceof ElementAccessSyntaxNode, true);
         }),
       ];
-      Test.assertSyntaxNodes(syntaxTests, PhpVersion.PHP7_0, PhpVersion.PHP7_4);
+      Test.assertSyntaxNodes(syntaxRegressionTests8_0, PhpVersion.PHP7_0, PhpVersion.PHP7_4);
 
       let diagnosticsTests = [
         new DiagnosticTestArgs('A{0};', 'should not parse element access of a constant', [ErrorCode.ERR_SemicolonExpected], [1]),
@@ -335,10 +335,15 @@ describe('PhpParser', function() {
       ];
       Test.assertDiagnostics(diagnosticsTests);
 
-      let deprecatedBraceSyntax = [
+      let diagnosticTests8_0 = [
+        new DiagnosticTestArgs('$a{0};', 'should not parse element access of an expression', [ErrorCode.ERR_SemicolonExpected], [2]),
+      ];
+      Test.assertDiagnostics(diagnosticTests8_0, PhpVersion.PHP8_0);
+
+      let diagnosticRegressionTests8_0 = [
         new DiagnosticTestArgs('$a{0};', 'should warn if brace syntax is used for element access', [ErrorCode.WRN_ElementAccessBraceSyntax], [2]),
       ];
-      Test.assertDiagnostics(deprecatedBraceSyntax, PhpVersion.PHP7_0, PhpVersion.PHP7_4);
+      Test.assertDiagnostics(diagnosticRegressionTests8_0, PhpVersion.PHP7_0, PhpVersion.PHP7_4);
     });
 
     describe('element-access-expression (without index)', function() {

--- a/test/src/parser/PhpParserTest_Expressions_Postfix.ts
+++ b/test/src/parser/PhpParserTest_Expressions_Postfix.ts
@@ -553,349 +553,7 @@ describe('PhpParser', function() {
       Test.assertSyntaxNodes(syntaxTests);
     });
 
-    describe('object-access-expression', function() {
-      let syntaxTests = [
-        // Variables.
-        new ParserTestArgs('$a->b;', 'object access of a variable', (statements, text) => {
-          let accessNode = assertNamedMemberAccess(statements, text, 'b');
-          assert.strictEqual(accessNode.dereferenceable instanceof LocalVariableSyntaxNode, true);
-        }),
-        new ParserTestArgs('$$a->b;', 'object access of a variable with variable name', (statements, text) => {
-          let accessNode = assertNamedMemberAccess(statements, text, 'b');
-          assert.strictEqual(accessNode.dereferenceable instanceof IndirectVariableSyntaxNode, true);
-        }),
-        new ParserTestArgs('${A}->b;', 'object access of a variable with expression name', (statements, text) => {
-          let accessNode = assertNamedMemberAccess(statements, text, 'b');
-          assert.strictEqual(accessNode.dereferenceable instanceof IndirectVariableSyntaxNode, true);
-        }),
-        // Expression group.
-        new ParserTestArgs('($a)->b;', 'object access of an expression group', (statements, text) => {
-          let accessNode = assertNamedMemberAccess(statements, text, 'b');
-          assert.strictEqual(accessNode.dereferenceable instanceof ExpressionGroupSyntaxNode, true);
-        }),
-        // Invocation.
-        new ParserTestArgs('a()->b;', 'object access of a function invocation', (statements, text) => {
-          let accessNode = assertNamedMemberAccess(statements, text, 'b');
-          assert.strictEqual(accessNode.dereferenceable instanceof FunctionInvocationSyntaxNode, true);
-        }),
-        new ParserTestArgs('A::b()->c;', 'object access of a static method invocation', (statements, text) => {
-          let accessNode = assertNamedMemberAccess(statements, text, 'c');
-          assert.strictEqual(accessNode.dereferenceable instanceof NamedScopedInvocationSyntaxNode, true);
-        }),
-        new ParserTestArgs('$a::b()->c;', 'object access of a static method invocation with class name reference', (statements, text) => {
-          let accessNode = assertNamedMemberAccess(statements, text, 'c');
-          assert.strictEqual(accessNode.dereferenceable instanceof NamedScopedInvocationSyntaxNode, true);
-        }),
-        new ParserTestArgs('$a->b()->c;', 'object access of a method invocation', (statements, text) => {
-          let accessNode = assertNamedMemberAccess(statements, text, 'c');
-          assert.strictEqual(accessNode.dereferenceable instanceof NamedMethodInvocationSyntaxNode, true);
-        }),
-        // Scoped access.
-        new ParserTestArgs('A::$b->c;', 'object access of a scoped access expression', (statements, text) => {
-          let accessNode = assertNamedMemberAccess(statements, text, 'c');
-          assert.strictEqual(accessNode.dereferenceable instanceof StaticPropertySyntaxNode, true);
-        }),
-        // Self.
-        new ParserTestArgs('$a->b->c;', 'object access of an object access expression', (statements, text) => {
-          let accessNode = assertNamedMemberAccess(statements, text, 'c');
-          assert.strictEqual(accessNode.dereferenceable instanceof NamedMemberAccessSyntaxNode, true);
-        }),
-
-        new ParserTestArgs('$a->class;', 'object access with keyword (class)', (statements, text) => {
-          let exprNode = <ExpressionStatementSyntaxNode>statements[0];
-          assert.strictEqual(exprNode instanceof ExpressionStatementSyntaxNode, true, 'ExpressionStatementSyntaxNode');
-          let memberAccess = <NamedMemberAccessSyntaxNode>exprNode.expression;
-          assert.strictEqual(memberAccess instanceof NamedMemberAccessSyntaxNode, true, 'NamedMemberAccessSyntaxNode');
-          Test.assertSyntaxToken(memberAccess.member, text, TokenKind.Class, 'class');
-          assert.strictEqual(memberAccess.dereferenceable instanceof LocalVariableSyntaxNode, true);
-        }),
-      ];
-      Test.assertSyntaxNodes(syntaxTests);
-
-      let diagnosticTests = [
-        new DiagnosticTestArgs('array()->', 'should not parse object access of an array', [ErrorCode.ERR_SemicolonExpected, ErrorCode.ERR_UnexpectedToken], [7, 7]),
-        new DiagnosticTestArgs('[]->', 'should not parse object access of an array (short syntax)', [ErrorCode.ERR_SemicolonExpected, ErrorCode.ERR_UnexpectedToken], [2, 2]),
-        new DiagnosticTestArgs('"A"->', 'should not parse object access of a string literal', [ErrorCode.ERR_SemicolonExpected, ErrorCode.ERR_UnexpectedToken], [3, 3]),
-        new DiagnosticTestArgs('A->', 'should not parse object access of a name', [ErrorCode.ERR_SemicolonExpected, ErrorCode.ERR_UnexpectedToken], [1, 1]),
-      ];
-      Test.assertDiagnostics(diagnosticTests);
-    });
-
-    describe('object-access-expression (null-safe)', function() {
-      let syntaxTests = [
-        // Variables.
-        new ParserTestArgs('$a?->b;', 'object access of a variable', (statements, text) => {
-          let accessNode = assertNamedMemberAccess(statements, text, 'b');
-          assert.strictEqual(accessNode.dereferenceable instanceof LocalVariableSyntaxNode, true);
-        }),
-        new ParserTestArgs('$$a?->b;', 'object access of a variable with variable name', (statements, text) => {
-          let accessNode = assertNamedMemberAccess(statements, text, 'b');
-          assert.strictEqual(accessNode.dereferenceable instanceof IndirectVariableSyntaxNode, true);
-        }),
-        new ParserTestArgs('${A}?->b;', 'object access of a variable with expression name', (statements, text) => {
-          let accessNode = assertNamedMemberAccess(statements, text, 'b');
-          assert.strictEqual(accessNode.dereferenceable instanceof IndirectVariableSyntaxNode, true);
-        }),
-        // Expression group.
-        new ParserTestArgs('($a)?->b;', 'object access of an expression group', (statements, text) => {
-          let accessNode = assertNamedMemberAccess(statements, text, 'b');
-          assert.strictEqual(accessNode.dereferenceable instanceof ExpressionGroupSyntaxNode, true);
-        }),
-        // Invocation.
-        new ParserTestArgs('a()?->b;', 'object access of a function invocation', (statements, text) => {
-          let accessNode = assertNamedMemberAccess(statements, text, 'b');
-          assert.strictEqual(accessNode.dereferenceable instanceof FunctionInvocationSyntaxNode, true);
-        }),
-        new ParserTestArgs('A::b()?->c;', 'object access of a static method invocation', (statements, text) => {
-          let accessNode = assertNamedMemberAccess(statements, text, 'c');
-          assert.strictEqual(accessNode.dereferenceable instanceof NamedScopedInvocationSyntaxNode, true);
-        }),
-        new ParserTestArgs('$a::b()?->c;', 'object access of a static method invocation with class name reference', (statements, text) => {
-          let accessNode = assertNamedMemberAccess(statements, text, 'c');
-          assert.strictEqual(accessNode.dereferenceable instanceof NamedScopedInvocationSyntaxNode, true);
-        }),
-        new ParserTestArgs('$a->b()?->c;', 'object access of a method invocation', (statements, text) => {
-          let accessNode = assertNamedMemberAccess(statements, text, 'c');
-          assert.strictEqual(accessNode.dereferenceable instanceof NamedMethodInvocationSyntaxNode, true);
-        }),
-        // Scoped access.
-        new ParserTestArgs('A::$b?->c;', 'object access of a scoped access expression', (statements, text) => {
-          let accessNode = assertNamedMemberAccess(statements, text, 'c');
-          assert.strictEqual(accessNode.dereferenceable instanceof StaticPropertySyntaxNode, true);
-        }),
-        // Self.
-        new ParserTestArgs('$a?->b?->c;', 'object access of an object access expression', (statements, text) => {
-          let accessNode = assertNamedMemberAccess(statements, text, 'c');
-          assert.strictEqual(accessNode.dereferenceable instanceof NamedMemberAccessSyntaxNode, true);
-        }),
-
-        new ParserTestArgs('$a?->class;', 'object access with keyword (class)', (statements, text) => {
-          let exprNode = <ExpressionStatementSyntaxNode>statements[0];
-          assert.strictEqual(exprNode instanceof ExpressionStatementSyntaxNode, true, 'ExpressionStatementSyntaxNode');
-          let memberAccess = <NamedMemberAccessSyntaxNode>exprNode.expression;
-          assert.strictEqual(memberAccess instanceof NamedMemberAccessSyntaxNode, true, 'NamedMemberAccessSyntaxNode');
-          Test.assertSyntaxToken(memberAccess.member, text, TokenKind.Class, 'class');
-          assert.strictEqual(memberAccess.dereferenceable instanceof LocalVariableSyntaxNode, true);
-        }),
-      ];
-      Test.assertSyntaxNodes(syntaxTests, PhpVersion.PHP8_0);
-
-      let diagnosticTests = [
-        new DiagnosticTestArgs('array()?->', 'should not parse object access of an array', [ErrorCode.ERR_SemicolonExpected, ErrorCode.ERR_UnexpectedToken], [7, 7]),
-        new DiagnosticTestArgs('[]?->', 'should not parse object access of an array (short syntax)', [ErrorCode.ERR_SemicolonExpected, ErrorCode.ERR_UnexpectedToken], [2, 2]),
-        new DiagnosticTestArgs('"A"?->', 'should not parse object access of a string literal', [ErrorCode.ERR_SemicolonExpected, ErrorCode.ERR_UnexpectedToken], [3, 3]),
-        new DiagnosticTestArgs('A?->', 'should not parse object access of a name', [ErrorCode.ERR_SemicolonExpected, ErrorCode.ERR_UnexpectedToken], [1, 1]),
-      ];
-      Test.assertDiagnostics(diagnosticTests, PhpVersion.PHP8_0);
-    });
-
-    // NOTE: Technically this should include "$a->{$b}" syntax as well.
-    describe('object-access-expression (indirect)', function() {
-      let syntaxTests = [
-        new ParserTestArgs('$a->$b;', 'object access of a variable', (statements) => {
-          let accessNode = assertIndirectMemberAccess(statements);
-          assert.strictEqual(accessNode.dereferenceable instanceof LocalVariableSyntaxNode, true);
-        }),
-        new ParserTestArgs('$$a->$b;', 'object access of a variable with variable name', (statements) => {
-          let accessNode = assertIndirectMemberAccess(statements);
-          assert.strictEqual(accessNode.dereferenceable instanceof IndirectVariableSyntaxNode, true);
-        }),
-        new ParserTestArgs('${A}->$b;', 'object access of a variable with expression name', (statements) => {
-          let accessNode = assertIndirectMemberAccess(statements);
-          assert.strictEqual(accessNode.dereferenceable instanceof IndirectVariableSyntaxNode, true);
-        }),
-        // Expression group.
-        new ParserTestArgs('($a)->$b;', 'object access of an expression group', (statements) => {
-          let accessNode = assertIndirectMemberAccess(statements);
-          assert.strictEqual(accessNode.dereferenceable instanceof ExpressionGroupSyntaxNode, true);
-        }),
-        // Invocation.
-        new ParserTestArgs('a()->$b;', 'object access of a function invocation', (statements) => {
-          let accessNode = assertIndirectMemberAccess(statements);
-          assert.strictEqual(accessNode.dereferenceable instanceof FunctionInvocationSyntaxNode, true);
-        }),
-        new ParserTestArgs('A::b()->$c;', 'object access of a static method invocation', (statements) => {
-          let accessNode = assertIndirectMemberAccess(statements);
-          assert.strictEqual(accessNode.dereferenceable instanceof NamedScopedInvocationSyntaxNode, true);
-        }),
-        new ParserTestArgs('$a::b()->$c;', 'object access of a static method invocation with class name reference', (statements) => {
-          let accessNode = assertIndirectMemberAccess(statements);
-          assert.strictEqual(accessNode.dereferenceable instanceof NamedScopedInvocationSyntaxNode, true);
-        }),
-        new ParserTestArgs('$a->b()->$c;', 'object access of a method invocation', (statements) => {
-          let accessNode = assertIndirectMemberAccess(statements);
-          assert.strictEqual(accessNode.dereferenceable instanceof NamedMethodInvocationSyntaxNode, true);
-        }),
-        // Scoped access.
-        new ParserTestArgs('A::$b->$c;', 'object access of a scoped access expression', (statements) => {
-          let accessNode = assertIndirectMemberAccess(statements);
-          assert.strictEqual(accessNode.dereferenceable instanceof StaticPropertySyntaxNode, true);
-        }),
-        // Self.
-        new ParserTestArgs('$a->b->$c;', 'object access of an object access expression', (statements) => {
-          let accessNode = assertIndirectMemberAccess(statements);
-          assert.strictEqual(accessNode.dereferenceable instanceof NamedMemberAccessSyntaxNode, true);
-        }),
-      ];
-      Test.assertSyntaxNodes(syntaxTests);
-    });
-
-    // NOTE: Does not include additional syntax variations for the member.
-    describe('scoped-access-expression (static property)', function() {
-      let syntaxTests = [
-        new ParserTestArgs('$a::$b;', 'scoped access of a variable', (statements) => {
-          let property = assertStaticProperty(statements);
-          assert.strictEqual(property.qualifier instanceof LocalVariableSyntaxNode, true);
-        }),
-        new ParserTestArgs('$$a::$b;', 'scoped access of a variable with variable name', (statements) => {
-          let property = assertStaticProperty(statements);
-          assert.strictEqual(property.qualifier instanceof IndirectVariableSyntaxNode, true);
-        }),
-        new ParserTestArgs('${A}::$b;', 'scoped access of a variable with expression name', (statements) => {
-          let property = assertStaticProperty(statements);
-          assert.strictEqual(property.qualifier instanceof IndirectVariableSyntaxNode, true);
-        }),
-        new ParserTestArgs('"a"::$b;', 'scoped access of a string literal', (statements) => {
-          let constant = assertStaticProperty(statements);
-          assert.strictEqual(constant.qualifier instanceof LiteralSyntaxNode, true);
-        }),
-        // Expression group.
-        new ParserTestArgs('($a)::$b;', 'scoped access of an expression group', (statements) => {
-          let property = assertStaticProperty(statements);
-          assert.strictEqual(property.qualifier instanceof ExpressionGroupSyntaxNode, true);
-        }),
-        // Invocation.
-        new ParserTestArgs('a()::$b;', 'scoped access of a function invocation', (statements) => {
-          let property = assertStaticProperty(statements);
-          assert.strictEqual(property.qualifier instanceof FunctionInvocationSyntaxNode, true);
-        }),
-        new ParserTestArgs('A::b()::$c;', 'scoped access of a static method invocation', (statements) => {
-          let property = assertStaticProperty(statements);
-          assert.strictEqual(property.qualifier instanceof NamedScopedInvocationSyntaxNode, true);
-        }),
-        new ParserTestArgs('$a::b()::$c;', 'scoped access of a static method invocation with class name reference', (statements) => {
-          let property = assertStaticProperty(statements);
-          assert.strictEqual(property.qualifier instanceof NamedScopedInvocationSyntaxNode, true);
-        }),
-        new ParserTestArgs('$a->b()::$c;', 'scoped access of a method invocation', (statements) => {
-          let property = assertStaticProperty(statements);
-          assert.strictEqual(property.qualifier instanceof NamedMethodInvocationSyntaxNode, true);
-        }),
-        // Names.
-        new ParserTestArgs('A::$b;', 'scoped access of a class name', (statements) => {
-          let property = assertStaticProperty(statements);
-          assert.strictEqual(property.qualifier instanceof PartiallyQualifiedNameSyntaxNode, true);
-        }),
-        new ParserTestArgs('\\A::$b;', 'scoped access of a class name (fully qualified)', (statements) => {
-          let property = assertStaticProperty(statements);
-          assert.strictEqual(property.qualifier instanceof FullyQualifiedNameSyntaxNode, true);
-        }),
-        new ParserTestArgs('namespace\\A::$b;', 'scoped access of a class name (relative)', (statements) => {
-          let property = assertStaticProperty(statements);
-          assert.strictEqual(property.qualifier instanceof RelativeNameSyntaxNode, true);
-        }),
-        new ParserTestArgs('static::$b;', 'scoped access of a class name (static keyword)', (statements) => {
-          let property = assertStaticProperty(statements);
-          assert.strictEqual(property.qualifier instanceof PartiallyQualifiedNameSyntaxNode, true);
-        }),
-        // Object access.
-        new ParserTestArgs('$a->b::$c;', 'scoped access of an object access expression', (statements) => {
-          let property = assertStaticProperty(statements);
-          assert.strictEqual(property.qualifier instanceof NamedMemberAccessSyntaxNode, true);
-        }),
-        // Self.
-        new ParserTestArgs('A::$b::$c;', 'scoped access of a scoped access expression', (statements) => {
-          let property = assertStaticProperty(statements);
-          assert.strictEqual(property.qualifier instanceof StaticPropertySyntaxNode, true);
-        }),
-      ];
-      Test.assertSyntaxNodes(syntaxTests);
-
-      let diagnosticTests = [
-        new DiagnosticTestArgs('array()::$b;', 'should not parse scoped access of an array', [ErrorCode.ERR_SemicolonExpected, ErrorCode.ERR_UnexpectedToken], [7, 7]),
-        new DiagnosticTestArgs('[]::$b;', 'should not parse scoped access of an array (short syntax)', [ErrorCode.ERR_SemicolonExpected, ErrorCode.ERR_UnexpectedToken], [2, 2]),
-      ];
-      Test.assertDiagnostics(diagnosticTests);
-    });
-
-    describe('scoped-access-expression (class constant)', function() {
-      let syntaxTests = [
-        new ParserTestArgs('$a::B;', 'scoped access of a variable', (statements, text) => {
-          let constant = assertClassConstant(statements, text, 'B');
-          assert.strictEqual(constant.qualifier instanceof LocalVariableSyntaxNode, true);
-        }),
-        new ParserTestArgs('$$a::B;', 'scoped access of a variable with variable name', (statements, text) => {
-          let constant = assertClassConstant(statements, text, 'B');
-          assert.strictEqual(constant.qualifier instanceof IndirectVariableSyntaxNode, true);
-        }),
-        new ParserTestArgs('${A}::B;', 'scoped access of a variable with expression name', (statements, text) => {
-          let constant = assertClassConstant(statements, text, 'B');
-          assert.strictEqual(constant.qualifier instanceof IndirectVariableSyntaxNode, true);
-        }),
-        new ParserTestArgs('"a"::B;', 'scoped access of a string literal', (statements, text) => {
-          let constant = assertClassConstant(statements, text, 'B');
-          assert.strictEqual(constant.qualifier instanceof LiteralSyntaxNode, true);
-        }),
-        // Expression group.
-        new ParserTestArgs('($a)::B;', 'scoped access of an expression group', (statements, text) => {
-          let constant = assertClassConstant(statements, text, 'B');
-          assert.strictEqual(constant.qualifier instanceof ExpressionGroupSyntaxNode, true);
-        }),
-        // Invocation.
-        new ParserTestArgs('a()::B;', 'scoped access of a function invocation', (statements, text) => {
-          let constant = assertClassConstant(statements, text, 'B');
-          assert.strictEqual(constant.qualifier instanceof FunctionInvocationSyntaxNode, true);
-        }),
-        new ParserTestArgs('A::b()::C;', 'scoped access of a static method invocation', (statements, text) => {
-          let constant = assertClassConstant(statements, text, 'C');
-          assert.strictEqual(constant.qualifier instanceof NamedScopedInvocationSyntaxNode, true);
-        }),
-        new ParserTestArgs('$a::b()::C;', 'scoped access of a static method invocation with class name reference', (statements, text) => {
-          let constant = assertClassConstant(statements, text, 'C');
-          assert.strictEqual(constant.qualifier instanceof NamedScopedInvocationSyntaxNode, true);
-        }),
-        new ParserTestArgs('$a->b()::C;', 'scoped access of a method invocation', (statements, text) => {
-          let constant = assertClassConstant(statements, text, 'C');
-          assert.strictEqual(constant.qualifier instanceof NamedMethodInvocationSyntaxNode, true);
-        }),
-        // Names.
-        new ParserTestArgs('A::B;', 'scoped access of a class name', (statements, text) => {
-          let constant = assertClassConstant(statements, text, 'B');
-          assert.strictEqual(constant.qualifier instanceof PartiallyQualifiedNameSyntaxNode, true);
-        }),
-        new ParserTestArgs('\\A::B;', 'scoped access of a class name (fully qualified)', (statements, text) => {
-          let constant = assertClassConstant(statements, text, 'B');
-          assert.strictEqual(constant.qualifier instanceof FullyQualifiedNameSyntaxNode, true);
-        }),
-        new ParserTestArgs('namespace\\A::B;', 'scoped access of a class name (relative)', (statements, text) => {
-          let constant = assertClassConstant(statements, text, 'B');
-          assert.strictEqual(constant.qualifier instanceof RelativeNameSyntaxNode, true);
-        }),
-        new ParserTestArgs('static::B;', 'scoped access of a class name (static keyword)', (statements, text) => {
-          let constant = assertClassConstant(statements, text, 'B');
-          assert.strictEqual(constant.qualifier instanceof PartiallyQualifiedNameSyntaxNode, true);
-        }),
-        // Object access.
-        new ParserTestArgs('$a->b::C;', 'scoped access of an object access expression', (statements, text) => {
-          let constant = assertClassConstant(statements, text, 'C');
-          assert.strictEqual(constant.qualifier instanceof NamedMemberAccessSyntaxNode, true);
-        }),
-        // Self.
-        new ParserTestArgs('A::$b::C;', 'scoped access of a scoped access expression', (statements, text) => {
-          let constant = assertClassConstant(statements, text, 'C');
-          assert.strictEqual(constant.qualifier instanceof StaticPropertySyntaxNode, true);
-        }),
-      ];
-      Test.assertSyntaxNodes(syntaxTests);
-
-      let diagnosticTests = [
-        new DiagnosticTestArgs('array()::B;', 'should not parse scoped access of an array', [ErrorCode.ERR_SemicolonExpected, ErrorCode.ERR_UnexpectedToken], [7, 7]),
-        new DiagnosticTestArgs('[]::B;', 'should not parse scoped access of an array (short syntax)', [ErrorCode.ERR_SemicolonExpected, ErrorCode.ERR_UnexpectedToken], [2, 2]),
-      ];
-      Test.assertDiagnostics(diagnosticTests);
-    });
-
-    describe('argument-list', function() {
+    describe('invocation-expression (argument-list)', function() {
       // NOTE: Empty argument lists are tested above.
       let syntaxTests = [
         new ParserTestArgs('a($b);', 'should parse an argument', (statements, text) => {
@@ -1014,6 +672,348 @@ describe('PhpParser', function() {
         new DiagnosticTestArgs('a(...$b,);', 'shoud not parse trailing comma in argument list (after unpacked argument)', [ErrorCode.ERR_FeatureTrailingCommasInArgumentLists], [7]),
       ];
       Test.assertDiagnostics(featureTrailingCommas, PhpVersion.PHP7_0, PhpVersion.PHP7_2);
+    });
+
+    describe('object-access-expression', function() {
+      let syntaxTests = [
+        // Variables.
+        new ParserTestArgs('$a->b;', 'object access of a variable', (statements, text) => {
+          let accessNode = assertNamedMemberAccess(statements, text, 'b');
+          assert.strictEqual(accessNode.dereferenceable instanceof LocalVariableSyntaxNode, true);
+        }),
+        new ParserTestArgs('$$a->b;', 'object access of a variable with variable name', (statements, text) => {
+          let accessNode = assertNamedMemberAccess(statements, text, 'b');
+          assert.strictEqual(accessNode.dereferenceable instanceof IndirectVariableSyntaxNode, true);
+        }),
+        new ParserTestArgs('${A}->b;', 'object access of a variable with expression name', (statements, text) => {
+          let accessNode = assertNamedMemberAccess(statements, text, 'b');
+          assert.strictEqual(accessNode.dereferenceable instanceof IndirectVariableSyntaxNode, true);
+        }),
+        // Expression group.
+        new ParserTestArgs('($a)->b;', 'object access of an expression group', (statements, text) => {
+          let accessNode = assertNamedMemberAccess(statements, text, 'b');
+          assert.strictEqual(accessNode.dereferenceable instanceof ExpressionGroupSyntaxNode, true);
+        }),
+        // Invocation.
+        new ParserTestArgs('a()->b;', 'object access of a function invocation', (statements, text) => {
+          let accessNode = assertNamedMemberAccess(statements, text, 'b');
+          assert.strictEqual(accessNode.dereferenceable instanceof FunctionInvocationSyntaxNode, true);
+        }),
+        new ParserTestArgs('A::b()->c;', 'object access of a static method invocation', (statements, text) => {
+          let accessNode = assertNamedMemberAccess(statements, text, 'c');
+          assert.strictEqual(accessNode.dereferenceable instanceof NamedScopedInvocationSyntaxNode, true);
+        }),
+        new ParserTestArgs('$a::b()->c;', 'object access of a static method invocation with class name reference', (statements, text) => {
+          let accessNode = assertNamedMemberAccess(statements, text, 'c');
+          assert.strictEqual(accessNode.dereferenceable instanceof NamedScopedInvocationSyntaxNode, true);
+        }),
+        new ParserTestArgs('$a->b()->c;', 'object access of a method invocation', (statements, text) => {
+          let accessNode = assertNamedMemberAccess(statements, text, 'c');
+          assert.strictEqual(accessNode.dereferenceable instanceof NamedMethodInvocationSyntaxNode, true);
+        }),
+        // Scoped access.
+        new ParserTestArgs('A::$b->c;', 'object access of a scoped access expression', (statements, text) => {
+          let accessNode = assertNamedMemberAccess(statements, text, 'c');
+          assert.strictEqual(accessNode.dereferenceable instanceof StaticPropertySyntaxNode, true);
+        }),
+        // Self.
+        new ParserTestArgs('$a->b->c;', 'object access of an object access expression', (statements, text) => {
+          let accessNode = assertNamedMemberAccess(statements, text, 'c');
+          assert.strictEqual(accessNode.dereferenceable instanceof NamedMemberAccessSyntaxNode, true);
+        }),
+
+        new ParserTestArgs('$a->class;', 'object access with keyword (class)', (statements, text) => {
+          let exprNode = <ExpressionStatementSyntaxNode>statements[0];
+          assert.strictEqual(exprNode instanceof ExpressionStatementSyntaxNode, true, 'ExpressionStatementSyntaxNode');
+          let memberAccess = <NamedMemberAccessSyntaxNode>exprNode.expression;
+          assert.strictEqual(memberAccess instanceof NamedMemberAccessSyntaxNode, true, 'NamedMemberAccessSyntaxNode');
+          Test.assertSyntaxToken(memberAccess.member, text, TokenKind.Class, 'class');
+          assert.strictEqual(memberAccess.dereferenceable instanceof LocalVariableSyntaxNode, true);
+        }),
+      ];
+      Test.assertSyntaxNodes(syntaxTests);
+
+      let diagnosticTests = [
+        new DiagnosticTestArgs('array()->', 'should not parse object access of an array', [ErrorCode.ERR_SemicolonExpected, ErrorCode.ERR_UnexpectedToken], [7, 7]),
+        new DiagnosticTestArgs('[]->', 'should not parse object access of an array (short syntax)', [ErrorCode.ERR_SemicolonExpected, ErrorCode.ERR_UnexpectedToken], [2, 2]),
+        new DiagnosticTestArgs('"A"->', 'should not parse object access of a string literal', [ErrorCode.ERR_SemicolonExpected, ErrorCode.ERR_UnexpectedToken], [3, 3]),
+        new DiagnosticTestArgs('A->', 'should not parse object access of a name', [ErrorCode.ERR_SemicolonExpected, ErrorCode.ERR_UnexpectedToken], [1, 1]),
+      ];
+      Test.assertDiagnostics(diagnosticTests);
+    });
+
+    // NOTE: Technically this should include "$a->{$b}" syntax as well.
+    describe('object-access-expression (indirect)', function() {
+      let syntaxTests = [
+        new ParserTestArgs('$a->$b;', 'object access of a variable', (statements) => {
+          let accessNode = assertIndirectMemberAccess(statements);
+          assert.strictEqual(accessNode.dereferenceable instanceof LocalVariableSyntaxNode, true);
+        }),
+        new ParserTestArgs('$$a->$b;', 'object access of a variable with variable name', (statements) => {
+          let accessNode = assertIndirectMemberAccess(statements);
+          assert.strictEqual(accessNode.dereferenceable instanceof IndirectVariableSyntaxNode, true);
+        }),
+        new ParserTestArgs('${A}->$b;', 'object access of a variable with expression name', (statements) => {
+          let accessNode = assertIndirectMemberAccess(statements);
+          assert.strictEqual(accessNode.dereferenceable instanceof IndirectVariableSyntaxNode, true);
+        }),
+        // Expression group.
+        new ParserTestArgs('($a)->$b;', 'object access of an expression group', (statements) => {
+          let accessNode = assertIndirectMemberAccess(statements);
+          assert.strictEqual(accessNode.dereferenceable instanceof ExpressionGroupSyntaxNode, true);
+        }),
+        // Invocation.
+        new ParserTestArgs('a()->$b;', 'object access of a function invocation', (statements) => {
+          let accessNode = assertIndirectMemberAccess(statements);
+          assert.strictEqual(accessNode.dereferenceable instanceof FunctionInvocationSyntaxNode, true);
+        }),
+        new ParserTestArgs('A::b()->$c;', 'object access of a static method invocation', (statements) => {
+          let accessNode = assertIndirectMemberAccess(statements);
+          assert.strictEqual(accessNode.dereferenceable instanceof NamedScopedInvocationSyntaxNode, true);
+        }),
+        new ParserTestArgs('$a::b()->$c;', 'object access of a static method invocation with class name reference', (statements) => {
+          let accessNode = assertIndirectMemberAccess(statements);
+          assert.strictEqual(accessNode.dereferenceable instanceof NamedScopedInvocationSyntaxNode, true);
+        }),
+        new ParserTestArgs('$a->b()->$c;', 'object access of a method invocation', (statements) => {
+          let accessNode = assertIndirectMemberAccess(statements);
+          assert.strictEqual(accessNode.dereferenceable instanceof NamedMethodInvocationSyntaxNode, true);
+        }),
+        // Scoped access.
+        new ParserTestArgs('A::$b->$c;', 'object access of a scoped access expression', (statements) => {
+          let accessNode = assertIndirectMemberAccess(statements);
+          assert.strictEqual(accessNode.dereferenceable instanceof StaticPropertySyntaxNode, true);
+        }),
+        // Self.
+        new ParserTestArgs('$a->b->$c;', 'object access of an object access expression', (statements) => {
+          let accessNode = assertIndirectMemberAccess(statements);
+          assert.strictEqual(accessNode.dereferenceable instanceof NamedMemberAccessSyntaxNode, true);
+        }),
+      ];
+      Test.assertSyntaxNodes(syntaxTests);
+    });
+
+    describe('object-access-expression (null-safe)', function() {
+      let syntaxTests = [
+        // Variables.
+        new ParserTestArgs('$a?->b;', 'object access of a variable', (statements, text) => {
+          let accessNode = assertNamedMemberAccess(statements, text, 'b');
+          assert.strictEqual(accessNode.dereferenceable instanceof LocalVariableSyntaxNode, true);
+        }),
+        new ParserTestArgs('$$a?->b;', 'object access of a variable with variable name', (statements, text) => {
+          let accessNode = assertNamedMemberAccess(statements, text, 'b');
+          assert.strictEqual(accessNode.dereferenceable instanceof IndirectVariableSyntaxNode, true);
+        }),
+        new ParserTestArgs('${A}?->b;', 'object access of a variable with expression name', (statements, text) => {
+          let accessNode = assertNamedMemberAccess(statements, text, 'b');
+          assert.strictEqual(accessNode.dereferenceable instanceof IndirectVariableSyntaxNode, true);
+        }),
+        // Expression group.
+        new ParserTestArgs('($a)?->b;', 'object access of an expression group', (statements, text) => {
+          let accessNode = assertNamedMemberAccess(statements, text, 'b');
+          assert.strictEqual(accessNode.dereferenceable instanceof ExpressionGroupSyntaxNode, true);
+        }),
+        // Invocation.
+        new ParserTestArgs('a()?->b;', 'object access of a function invocation', (statements, text) => {
+          let accessNode = assertNamedMemberAccess(statements, text, 'b');
+          assert.strictEqual(accessNode.dereferenceable instanceof FunctionInvocationSyntaxNode, true);
+        }),
+        new ParserTestArgs('A::b()?->c;', 'object access of a static method invocation', (statements, text) => {
+          let accessNode = assertNamedMemberAccess(statements, text, 'c');
+          assert.strictEqual(accessNode.dereferenceable instanceof NamedScopedInvocationSyntaxNode, true);
+        }),
+        new ParserTestArgs('$a::b()?->c;', 'object access of a static method invocation with class name reference', (statements, text) => {
+          let accessNode = assertNamedMemberAccess(statements, text, 'c');
+          assert.strictEqual(accessNode.dereferenceable instanceof NamedScopedInvocationSyntaxNode, true);
+        }),
+        new ParserTestArgs('$a->b()?->c;', 'object access of a method invocation', (statements, text) => {
+          let accessNode = assertNamedMemberAccess(statements, text, 'c');
+          assert.strictEqual(accessNode.dereferenceable instanceof NamedMethodInvocationSyntaxNode, true);
+        }),
+        // Scoped access.
+        new ParserTestArgs('A::$b?->c;', 'object access of a scoped access expression', (statements, text) => {
+          let accessNode = assertNamedMemberAccess(statements, text, 'c');
+          assert.strictEqual(accessNode.dereferenceable instanceof StaticPropertySyntaxNode, true);
+        }),
+        // Self.
+        new ParserTestArgs('$a?->b?->c;', 'object access of an object access expression', (statements, text) => {
+          let accessNode = assertNamedMemberAccess(statements, text, 'c');
+          assert.strictEqual(accessNode.dereferenceable instanceof NamedMemberAccessSyntaxNode, true);
+        }),
+
+        new ParserTestArgs('$a?->class;', 'object access with keyword (class)', (statements, text) => {
+          let exprNode = <ExpressionStatementSyntaxNode>statements[0];
+          assert.strictEqual(exprNode instanceof ExpressionStatementSyntaxNode, true, 'ExpressionStatementSyntaxNode');
+          let memberAccess = <NamedMemberAccessSyntaxNode>exprNode.expression;
+          assert.strictEqual(memberAccess instanceof NamedMemberAccessSyntaxNode, true, 'NamedMemberAccessSyntaxNode');
+          Test.assertSyntaxToken(memberAccess.member, text, TokenKind.Class, 'class');
+          assert.strictEqual(memberAccess.dereferenceable instanceof LocalVariableSyntaxNode, true);
+        }),
+      ];
+      Test.assertSyntaxNodes(syntaxTests, PhpVersion.PHP8_0);
+
+      let diagnosticTests = [
+        new DiagnosticTestArgs('array()?->', 'should not parse object access of an array', [ErrorCode.ERR_SemicolonExpected, ErrorCode.ERR_UnexpectedToken], [7, 7]),
+        new DiagnosticTestArgs('[]?->', 'should not parse object access of an array (short syntax)', [ErrorCode.ERR_SemicolonExpected, ErrorCode.ERR_UnexpectedToken], [2, 2]),
+        new DiagnosticTestArgs('"A"?->', 'should not parse object access of a string literal', [ErrorCode.ERR_SemicolonExpected, ErrorCode.ERR_UnexpectedToken], [3, 3]),
+        new DiagnosticTestArgs('A?->', 'should not parse object access of a name', [ErrorCode.ERR_SemicolonExpected, ErrorCode.ERR_UnexpectedToken], [1, 1]),
+      ];
+      Test.assertDiagnostics(diagnosticTests, PhpVersion.PHP8_0);
+    });
+
+    describe('scoped-access-expression (class constant)', function() {
+      let syntaxTests = [
+        new ParserTestArgs('$a::B;', 'scoped access of a variable', (statements, text) => {
+          let constant = assertClassConstant(statements, text, 'B');
+          assert.strictEqual(constant.qualifier instanceof LocalVariableSyntaxNode, true);
+        }),
+        new ParserTestArgs('$$a::B;', 'scoped access of a variable with variable name', (statements, text) => {
+          let constant = assertClassConstant(statements, text, 'B');
+          assert.strictEqual(constant.qualifier instanceof IndirectVariableSyntaxNode, true);
+        }),
+        new ParserTestArgs('${A}::B;', 'scoped access of a variable with expression name', (statements, text) => {
+          let constant = assertClassConstant(statements, text, 'B');
+          assert.strictEqual(constant.qualifier instanceof IndirectVariableSyntaxNode, true);
+        }),
+        new ParserTestArgs('"a"::B;', 'scoped access of a string literal', (statements, text) => {
+          let constant = assertClassConstant(statements, text, 'B');
+          assert.strictEqual(constant.qualifier instanceof LiteralSyntaxNode, true);
+        }),
+        // Expression group.
+        new ParserTestArgs('($a)::B;', 'scoped access of an expression group', (statements, text) => {
+          let constant = assertClassConstant(statements, text, 'B');
+          assert.strictEqual(constant.qualifier instanceof ExpressionGroupSyntaxNode, true);
+        }),
+        // Invocation.
+        new ParserTestArgs('a()::B;', 'scoped access of a function invocation', (statements, text) => {
+          let constant = assertClassConstant(statements, text, 'B');
+          assert.strictEqual(constant.qualifier instanceof FunctionInvocationSyntaxNode, true);
+        }),
+        new ParserTestArgs('A::b()::C;', 'scoped access of a static method invocation', (statements, text) => {
+          let constant = assertClassConstant(statements, text, 'C');
+          assert.strictEqual(constant.qualifier instanceof NamedScopedInvocationSyntaxNode, true);
+        }),
+        new ParserTestArgs('$a::b()::C;', 'scoped access of a static method invocation with class name reference', (statements, text) => {
+          let constant = assertClassConstant(statements, text, 'C');
+          assert.strictEqual(constant.qualifier instanceof NamedScopedInvocationSyntaxNode, true);
+        }),
+        new ParserTestArgs('$a->b()::C;', 'scoped access of a method invocation', (statements, text) => {
+          let constant = assertClassConstant(statements, text, 'C');
+          assert.strictEqual(constant.qualifier instanceof NamedMethodInvocationSyntaxNode, true);
+        }),
+        // Names.
+        new ParserTestArgs('A::B;', 'scoped access of a class name', (statements, text) => {
+          let constant = assertClassConstant(statements, text, 'B');
+          assert.strictEqual(constant.qualifier instanceof PartiallyQualifiedNameSyntaxNode, true);
+        }),
+        new ParserTestArgs('\\A::B;', 'scoped access of a class name (fully qualified)', (statements, text) => {
+          let constant = assertClassConstant(statements, text, 'B');
+          assert.strictEqual(constant.qualifier instanceof FullyQualifiedNameSyntaxNode, true);
+        }),
+        new ParserTestArgs('namespace\\A::B;', 'scoped access of a class name (relative)', (statements, text) => {
+          let constant = assertClassConstant(statements, text, 'B');
+          assert.strictEqual(constant.qualifier instanceof RelativeNameSyntaxNode, true);
+        }),
+        new ParserTestArgs('static::B;', 'scoped access of a class name (static keyword)', (statements, text) => {
+          let constant = assertClassConstant(statements, text, 'B');
+          assert.strictEqual(constant.qualifier instanceof PartiallyQualifiedNameSyntaxNode, true);
+        }),
+        // Object access.
+        new ParserTestArgs('$a->b::C;', 'scoped access of an object access expression', (statements, text) => {
+          let constant = assertClassConstant(statements, text, 'C');
+          assert.strictEqual(constant.qualifier instanceof NamedMemberAccessSyntaxNode, true);
+        }),
+        // Self.
+        new ParserTestArgs('A::$b::C;', 'scoped access of a scoped access expression', (statements, text) => {
+          let constant = assertClassConstant(statements, text, 'C');
+          assert.strictEqual(constant.qualifier instanceof StaticPropertySyntaxNode, true);
+        }),
+      ];
+      Test.assertSyntaxNodes(syntaxTests);
+
+      let diagnosticTests = [
+        new DiagnosticTestArgs('array()::B;', 'should not parse scoped access of an array', [ErrorCode.ERR_SemicolonExpected, ErrorCode.ERR_UnexpectedToken], [7, 7]),
+        new DiagnosticTestArgs('[]::B;', 'should not parse scoped access of an array (short syntax)', [ErrorCode.ERR_SemicolonExpected, ErrorCode.ERR_UnexpectedToken], [2, 2]),
+      ];
+      Test.assertDiagnostics(diagnosticTests);
+    });
+
+    // NOTE: Does not include additional syntax variations for the member.
+    describe('scoped-access-expression (static property)', function() {
+      let syntaxTests = [
+        new ParserTestArgs('$a::$b;', 'scoped access of a variable', (statements) => {
+          let property = assertStaticProperty(statements);
+          assert.strictEqual(property.qualifier instanceof LocalVariableSyntaxNode, true);
+        }),
+        new ParserTestArgs('$$a::$b;', 'scoped access of a variable with variable name', (statements) => {
+          let property = assertStaticProperty(statements);
+          assert.strictEqual(property.qualifier instanceof IndirectVariableSyntaxNode, true);
+        }),
+        new ParserTestArgs('${A}::$b;', 'scoped access of a variable with expression name', (statements) => {
+          let property = assertStaticProperty(statements);
+          assert.strictEqual(property.qualifier instanceof IndirectVariableSyntaxNode, true);
+        }),
+        new ParserTestArgs('"a"::$b;', 'scoped access of a string literal', (statements) => {
+          let constant = assertStaticProperty(statements);
+          assert.strictEqual(constant.qualifier instanceof LiteralSyntaxNode, true);
+        }),
+        // Expression group.
+        new ParserTestArgs('($a)::$b;', 'scoped access of an expression group', (statements) => {
+          let property = assertStaticProperty(statements);
+          assert.strictEqual(property.qualifier instanceof ExpressionGroupSyntaxNode, true);
+        }),
+        // Invocation.
+        new ParserTestArgs('a()::$b;', 'scoped access of a function invocation', (statements) => {
+          let property = assertStaticProperty(statements);
+          assert.strictEqual(property.qualifier instanceof FunctionInvocationSyntaxNode, true);
+        }),
+        new ParserTestArgs('A::b()::$c;', 'scoped access of a static method invocation', (statements) => {
+          let property = assertStaticProperty(statements);
+          assert.strictEqual(property.qualifier instanceof NamedScopedInvocationSyntaxNode, true);
+        }),
+        new ParserTestArgs('$a::b()::$c;', 'scoped access of a static method invocation with class name reference', (statements) => {
+          let property = assertStaticProperty(statements);
+          assert.strictEqual(property.qualifier instanceof NamedScopedInvocationSyntaxNode, true);
+        }),
+        new ParserTestArgs('$a->b()::$c;', 'scoped access of a method invocation', (statements) => {
+          let property = assertStaticProperty(statements);
+          assert.strictEqual(property.qualifier instanceof NamedMethodInvocationSyntaxNode, true);
+        }),
+        // Names.
+        new ParserTestArgs('A::$b;', 'scoped access of a class name', (statements) => {
+          let property = assertStaticProperty(statements);
+          assert.strictEqual(property.qualifier instanceof PartiallyQualifiedNameSyntaxNode, true);
+        }),
+        new ParserTestArgs('\\A::$b;', 'scoped access of a class name (fully qualified)', (statements) => {
+          let property = assertStaticProperty(statements);
+          assert.strictEqual(property.qualifier instanceof FullyQualifiedNameSyntaxNode, true);
+        }),
+        new ParserTestArgs('namespace\\A::$b;', 'scoped access of a class name (relative)', (statements) => {
+          let property = assertStaticProperty(statements);
+          assert.strictEqual(property.qualifier instanceof RelativeNameSyntaxNode, true);
+        }),
+        new ParserTestArgs('static::$b;', 'scoped access of a class name (static keyword)', (statements) => {
+          let property = assertStaticProperty(statements);
+          assert.strictEqual(property.qualifier instanceof PartiallyQualifiedNameSyntaxNode, true);
+        }),
+        // Object access.
+        new ParserTestArgs('$a->b::$c;', 'scoped access of an object access expression', (statements) => {
+          let property = assertStaticProperty(statements);
+          assert.strictEqual(property.qualifier instanceof NamedMemberAccessSyntaxNode, true);
+        }),
+        // Self.
+        new ParserTestArgs('A::$b::$c;', 'scoped access of a scoped access expression', (statements) => {
+          let property = assertStaticProperty(statements);
+          assert.strictEqual(property.qualifier instanceof StaticPropertySyntaxNode, true);
+        }),
+      ];
+      Test.assertSyntaxNodes(syntaxTests);
+
+      let diagnosticTests = [
+        new DiagnosticTestArgs('array()::$b;', 'should not parse scoped access of an array', [ErrorCode.ERR_SemicolonExpected, ErrorCode.ERR_UnexpectedToken], [7, 7]),
+        new DiagnosticTestArgs('[]::$b;', 'should not parse scoped access of an array (short syntax)', [ErrorCode.ERR_SemicolonExpected, ErrorCode.ERR_UnexpectedToken], [2, 2]),
+      ];
+      Test.assertDiagnostics(diagnosticTests);
     });
 
   });

--- a/test/src/parser/PhpParserTest_Expressions_Postfix.ts
+++ b/test/src/parser/PhpParserTest_Expressions_Postfix.ts
@@ -923,7 +923,8 @@ describe('PhpParser', function() {
       Test.assertDiagnostics(diagnosticTests7_3, PhpVersion.PHP7_3);
 
       let featureTrailingCommas = [
-        new DiagnosticTestArgs('a($b,);', 'shoud not parse trailing comma in argument list', [ErrorCode.ERR_FeatureTrailingCommasInArgumentLists], [4]),
+        new DiagnosticTestArgs('a($b,', 'shoud not parse trailing comma in argument list', [ErrorCode.ERR_FeatureTrailingCommasInArgumentLists, ErrorCode.ERR_ExpressionOrCloseParenExpected], [4, 5]),
+        new DiagnosticTestArgs('a($b,);', 'shoud not parse trailing comma in argument list (completed)', [ErrorCode.ERR_FeatureTrailingCommasInArgumentLists], [4]),
         new DiagnosticTestArgs('a($b, $c,);', 'shoud not parse trailing comma in argument list (multiple arguments)', [ErrorCode.ERR_FeatureTrailingCommasInArgumentLists], [8]),
         new DiagnosticTestArgs('a(...$b,);', 'shoud not parse trailing comma in argument list (after unpacked argument)', [ErrorCode.ERR_FeatureTrailingCommasInArgumentLists], [7]),
       ];

--- a/test/src/parser/PhpParserTest_Expressions_Strings.ts
+++ b/test/src/parser/PhpParserTest_Expressions_Strings.ts
@@ -170,6 +170,18 @@ describe('PhpParser', function() {
     ];
     Test.assertSyntaxNodes(syntaxTests);
 
+    let syntaxTests8_0 = [
+      new ParserTestArgs('"$a?->b";', 'should parse a template using null-safe member access', (statements) => {
+        let contents = assertStringTemplate(statements);
+        assert.strictEqual(contents[0] instanceof NamedMemberAccessSyntaxNode, true);
+      }),
+      new ParserTestArgs('"$a?->class";', 'should parse a template using null-safe member access with keyword (class)', (statements) => {
+        let contents = assertStringTemplate(statements);
+        assert.strictEqual(contents[0] instanceof NamedMemberAccessSyntaxNode, true);
+      }),
+    ];
+    Test.assertSyntaxNodes(syntaxTests8_0, PhpVersion.PHP8_0);
+
     let diagnosticTests = [
       // All incomplete variables are just plain variables followed by strings.
 

--- a/test/src/parser/PhpParserTest_Expressions_Strings.ts
+++ b/test/src/parser/PhpParserTest_Expressions_Strings.ts
@@ -64,7 +64,7 @@ function assertFlexibleHeredocLine(node: ISyntaxNode, sourceText: string, indent
   }
   else {
     // Interpolations.
-    assert.notEqual(template.length, 0);
+    assert.notStrictEqual(template.length, 0);
   }
   return template;
 }

--- a/test/src/parser/PhpParserTest_FunctionDeclaration.ts
+++ b/test/src/parser/PhpParserTest_FunctionDeclaration.ts
@@ -154,6 +154,13 @@ describe('PhpParser', function() {
     Test.assertSyntaxNodes(syntaxTests7_1, PhpVersion.PHP7_1);
 
     let syntaxTests8_0 = [
+      new ParserTestArgs('function a(): static {}', 'should parse a function with static return type', (statements) => {
+        let funcDecl = <FunctionDeclarationSyntaxNode>statements[0];
+        assert.strictEqual(funcDecl instanceof FunctionDeclarationSyntaxNode, true, 'FunctionDeclarationSyntaxNode');
+        assert.strictEqual(funcDecl.ampersand, null);
+        assert.strictEqual(funcDecl.parameters, null);
+        assert.strictEqual(funcDecl.returnType instanceof PredefinedTypeSyntaxNode, true, 'PredefinedTypeSyntaxNode');
+      }),
       new ParserTestArgs('function a(): B | callable {}', 'should parse a function with type union', (statements) => {
         let funcDecl = <FunctionDeclarationSyntaxNode>statements[0];
         assert.strictEqual(funcDecl instanceof FunctionDeclarationSyntaxNode, true, 'FunctionDeclarationSyntaxNode');
@@ -191,6 +198,7 @@ describe('PhpParser', function() {
     let diagnosticRegressionTests8_0 = [
       new DiagnosticTestArgs('function a(): B', 'missing open brace', [ErrorCode.ERR_OpenBraceExpected], [15]),
       new DiagnosticTestArgs('function a(): B | C {}', 'should not parse a type union', [ErrorCode.ERR_FeatureUnionTypes], [14]),
+      new DiagnosticTestArgs('function a(): static {}', 'should not parse a static return type', [ErrorCode.ERR_FeatureStaticReturnType], [14]),
     ];
     Test.assertDiagnostics(diagnosticRegressionTests8_0, PhpVersion.PHP7_0, PhpVersion.PHP7_4);
   });

--- a/test/src/parser/PhpParserTest_FunctionDeclaration.ts
+++ b/test/src/parser/PhpParserTest_FunctionDeclaration.ts
@@ -309,6 +309,17 @@ describe('PhpParser', function() {
     Test.assertSyntaxNodes(syntaxTests7_1, PhpVersion.PHP7_1);
 
     let syntaxTests8_0 = [
+      new ParserTestArgs('function a($b,) {}', 'should parse a parameter with trailing comma', (statements) => {
+        let parameters = assertFunctionWithParameters(statements);
+        assert.strictEqual(parameters.length, 1);
+        assertParameter(parameters[0], false, false, false, false);
+      }),
+      new ParserTestArgs('function a($b, $c,) {}', 'should parse multiple parameters with trailing comma', (statements) => {
+        let parameters = assertFunctionWithParameters(statements);
+        assert.strictEqual(parameters.length, 2);
+        assertParameter(parameters[0], false, false, false, false);
+        assertParameter(parameters[1], false, false, false, false);
+      }),
       new ParserTestArgs('function a(B | callable $d) {}', 'should parse a parameter with type union', (statements) => {
         let parameters = assertFunctionWithParameters(statements);
         assert.strictEqual(parameters.length, 1);
@@ -329,9 +340,7 @@ describe('PhpParser', function() {
       new DiagnosticTestArgs('function a($b', 'missing comma, close paren, or equals', [ErrorCode.ERR_IncompleteParameterList], [13]),
       new DiagnosticTestArgs('function a($b =', 'missing expression', [ErrorCode.ERR_ExpressionExpectedEOF], [15]),
       new DiagnosticTestArgs('function a($b = 1', 'missing comma or close paren', [ErrorCode.ERR_CommaOrCloseParenExpected], [17]),
-      new DiagnosticTestArgs('function a($b,', 'missing ampersand, ellipsis, question, type, or variable', [ErrorCode.ERR_ParameterExpected], [14]),
       new DiagnosticTestArgs('function a(...', 'missing variable', [ErrorCode.ERR_VariableExpected], [14]),
-      new DiagnosticTestArgs('function a(...$b', 'missing close paren', [ErrorCode.ERR_CloseParenExpected], [16]),
 
       new DiagnosticTestArgs('function a(...$b = []) {}', 'should not parse variadic parameter with default value', [ErrorCode.ERR_VariadicHasDefaultValue], [17]),
       new DiagnosticTestArgs('function a(...$b, $c) {}', 'should not parse parameter after variadic parameter', [ErrorCode.ERR_VariadicIsNotLastParameter], [11]),
@@ -355,6 +364,9 @@ describe('PhpParser', function() {
     Test.assertDiagnostics(diagnosticRegressionTests7_1, PhpVersion.PHP7_0, PhpVersion.PHP7_0);
 
     let diagnosticTests8_0 = [
+      new DiagnosticTestArgs('function a($b,', 'missing ampersand, ellipsis, question, type, variable, or close paren', [ErrorCode.ERR_ParameterOrCloseParenExpected], [14]),
+      new DiagnosticTestArgs('function a(...$b', 'missing comma or close paren', [ErrorCode.ERR_CloseParenExpected], [16]),
+      new DiagnosticTestArgs('function a(...$b,', 'missing close paren', [ErrorCode.ERR_CloseParenExpected], [17]),
       new DiagnosticTestArgs('function a(B', 'missing ampersand, ellipsis, variable, or vertical bar', [ErrorCode.ERR_IncompleteParameter], [12]),
       new DiagnosticTestArgs('function a(B |', 'missing type', [ErrorCode.ERR_TypeExpected], [14]),
       new DiagnosticTestArgs('function a(B | C', 'missing ampersand, ellipsis, variable, or vertical bar (after multiple types)', [ErrorCode.ERR_IncompleteParameter], [16]),
@@ -364,6 +376,10 @@ describe('PhpParser', function() {
     Test.assertDiagnostics(diagnosticTests8_0, PhpVersion.PHP8_0);
 
     let diagnosticRegressionTests8_0 = [
+      new DiagnosticTestArgs('function a($b,', 'missing ampersand, ellipsis, question, type, or variable', [ErrorCode.ERR_FeatureTrailingCommasInParameterLists, ErrorCode.ERR_ParameterOrCloseParenExpected], [13, 14]),
+      new DiagnosticTestArgs('function a($b,) {}', 'should not parse trailing comma in parameter list', [ErrorCode.ERR_FeatureTrailingCommasInParameterLists], [13]),
+      new DiagnosticTestArgs('function a(...$b', 'missing close paren', [ErrorCode.ERR_CloseParenExpected], [16]),
+      new DiagnosticTestArgs('function a(...$b,', 'should not parse trailing comma in parameter list (variadic)', [ErrorCode.ERR_FeatureTrailingCommasInParameterLists, ErrorCode.ERR_CloseParenExpected], [16, 17]),
       new DiagnosticTestArgs('function a(B', 'missing ampersand, ellipsis, or variable', [ErrorCode.ERR_IncompleteParameter], [12]),
       new DiagnosticTestArgs('function a(B | C $d) {}', 'should not parse a type union', [ErrorCode.ERR_FeatureUnionTypes], [11]),
     ];

--- a/test/src/parser/PhpParserTest_FunctionDeclaration.ts
+++ b/test/src/parser/PhpParserTest_FunctionDeclaration.ts
@@ -52,6 +52,7 @@ function assertFunctionWithParameters(statements: ISyntaxNode[]): ISyntaxNode[] 
 function assertParameter(node: ISyntaxNode, hasType: boolean, hasAmpersand: boolean, hasEllipsis: boolean, hasDefaultValue: boolean): ParameterSyntaxNode {
   let parameter = <ParameterSyntaxNode>node;
   assert.strictEqual(parameter instanceof ParameterSyntaxNode, true, 'ParameterSyntaxNode');
+  assert.strictEqual(parameter.modifiers, null);
   if (!hasType) {
     assert.strictEqual(parameter.type, null);
   }
@@ -284,6 +285,9 @@ describe('PhpParser', function() {
 
       // @todo Recovery tests.
       new DiagnosticTestArgs('function a($', 'missing variable name', [ErrorCode.ERR_VariableNameExpected], [11]),
+      // @todo It may be worth allowing this for error recovery purposes in the
+      //   future. A user may be refactoring a method into a regular function.
+      new DiagnosticTestArgs('function a(public $b) {}', 'should not parse a parameter with modifier', [ErrorCode.ERR_ParameterOrCloseParenExpected], [11]),
     ];
     Test.assertDiagnostics(diagnosticTests);
 

--- a/test/src/parser/PhpParserTest_InterfaceDeclaration.ts
+++ b/test/src/parser/PhpParserTest_InterfaceDeclaration.ts
@@ -51,7 +51,7 @@ function assertClassConstantDeclaration(statements: ISyntaxNode[]): ClassConstan
   let members = interfaceNode.members ? interfaceNode.members.childNodes() : [];
   assert.strictEqual(members.length, 1);
   let classConstant = <ClassConstantDeclarationSyntaxNode>members[0];
-  assert.strictEqual(classConstant instanceof ClassConstantDeclarationSyntaxNode, true);
+  assert.strictEqual(classConstant instanceof ClassConstantDeclarationSyntaxNode, true, 'ClassConstantDeclarationSyntaxNode');
   return classConstant;
 }
 
@@ -61,7 +61,7 @@ function assertMethodDeclaration(statements: ISyntaxNode[]): MethodDeclarationSy
   let members = interfaceNode.members ? interfaceNode.members.childNodes() : [];
   assert.strictEqual(members.length, 1);
   let method = <MethodDeclarationSyntaxNode>members[0];
-  assert.strictEqual(method instanceof MethodDeclarationSyntaxNode, true);
+  assert.strictEqual(method instanceof MethodDeclarationSyntaxNode, true, 'MethodDeclarationSyntaxNode');
   return method;
 }
 

--- a/test/src/parser/PhpParserTest_InterfaceDeclaration.ts
+++ b/test/src/parser/PhpParserTest_InterfaceDeclaration.ts
@@ -370,6 +370,13 @@ describe('PhpParser', function() {
       Test.assertSyntaxNodes(syntaxTests7_1, PhpVersion.PHP7_1);
 
       let syntaxTests8_0 = [
+        new ParserTestArgs('interface A { function b(): static; }', 'should parse a method declaration with static return type', (statements, text) => {
+          let method = assertMethodDeclaration(statements);
+          assert.strictEqual(method.modifiers, null);
+          assert.strictEqual(method.ampersand, null);
+          Test.assertSyntaxToken(method.identifierOrKeyword, text, TokenKind.Identifier, 'b');
+          assert.strictEqual(method.returnType instanceof PredefinedTypeSyntaxNode, true, 'PredefinedTypeSyntaxNode');
+        }),
         new ParserTestArgs('interface A { function b(): array | C; }', 'should parse a method declaration with type union', (statements, text) => {
           let method = assertMethodDeclaration(statements);
           assert.strictEqual(method.modifiers, null);
@@ -416,6 +423,7 @@ describe('PhpParser', function() {
       let diagnosticRegressionTests8_0 = [
         new DiagnosticTestArgs('interface A { function b(): C }', 'missing semicolon', [ErrorCode.ERR_SemicolonExpected], [29]),
         new DiagnosticTestArgs('interface A { function b(): C | D; }', 'should not parse a type union', [ErrorCode.ERR_FeatureUnionTypes], [28]),
+        new DiagnosticTestArgs('interface A { function b(): static; }', 'should not parse a static return type', [ErrorCode.ERR_FeatureStaticReturnType], [28]),
       ];
       Test.assertDiagnostics(diagnosticRegressionTests8_0, PhpVersion.PHP7_0, PhpVersion.PHP7_4);
     });

--- a/test/src/parser/PhpParserTest_InterfaceDeclaration.ts
+++ b/test/src/parser/PhpParserTest_InterfaceDeclaration.ts
@@ -47,7 +47,7 @@ import { TokenKind } from '../../../src/language/TokenKind';
 
 function assertClassConstantDeclaration(statements: ISyntaxNode[]): ClassConstantDeclarationSyntaxNode {
   let interfaceNode = <InterfaceDeclarationSyntaxNode>statements[0];
-  assert.strictEqual(interfaceNode instanceof InterfaceDeclarationSyntaxNode, true, 'is a InterfaceDeclarationSyntaxNode');
+  assert.strictEqual(interfaceNode instanceof InterfaceDeclarationSyntaxNode, true, 'InterfaceDeclarationSyntaxNode');
   let members = interfaceNode.members ? interfaceNode.members.childNodes() : [];
   assert.strictEqual(members.length, 1);
   let classConstant = <ClassConstantDeclarationSyntaxNode>members[0];
@@ -57,7 +57,7 @@ function assertClassConstantDeclaration(statements: ISyntaxNode[]): ClassConstan
 
 function assertMethodDeclaration(statements: ISyntaxNode[]): MethodDeclarationSyntaxNode {
   let interfaceNode = <InterfaceDeclarationSyntaxNode>statements[0];
-  assert.strictEqual(interfaceNode instanceof InterfaceDeclarationSyntaxNode, true, 'is a InterfaceDeclarationSyntaxNode');
+  assert.strictEqual(interfaceNode instanceof InterfaceDeclarationSyntaxNode, true, 'InterfaceDeclarationSyntaxNode');
   let members = interfaceNode.members ? interfaceNode.members.childNodes() : [];
   assert.strictEqual(members.length, 1);
   let method = <MethodDeclarationSyntaxNode>members[0];
@@ -108,14 +108,14 @@ describe('PhpParser', function() {
     let syntaxTests = [
       new ParserTestArgs('interface A {}', 'should parse an interface declaration', (statements, text) => {
         let interfaceNode = <InterfaceDeclarationSyntaxNode>statements[0];
-        assert.strictEqual(interfaceNode instanceof InterfaceDeclarationSyntaxNode, true, 'is a InterfaceDeclarationSyntaxNode');
+        assert.strictEqual(interfaceNode instanceof InterfaceDeclarationSyntaxNode, true, 'InterfaceDeclarationSyntaxNode');
         Test.assertSyntaxToken(interfaceNode.identifier, text, TokenKind.Identifier, 'A');
         assert.strictEqual(interfaceNode.baseInterfaces, null);
         assert.strictEqual(interfaceNode.members, null);
       }),
       new ParserTestArgs('{ interface A {} }', 'should parse an interface declaration in statement block', (statements) => {
         let block = <StatementBlockSyntaxNode>statements[0];
-        assert.strictEqual(block instanceof StatementBlockSyntaxNode, true, 'is a StatementBlockSyntaxNode');
+        assert.strictEqual(block instanceof StatementBlockSyntaxNode, true, 'StatementBlockSyntaxNode');
         let innerStatements = block.childNodes();
         assert.strictEqual(innerStatements.length, 1);
         assert.strictEqual(innerStatements[0] instanceof InterfaceDeclarationSyntaxNode, true);
@@ -141,7 +141,7 @@ describe('PhpParser', function() {
     let syntaxTests = [
       new ParserTestArgs('interface A extends B {}', 'should parse an interface declaration with single base type', (statements) => {
         let interfaceNode = <InterfaceDeclarationSyntaxNode>statements[0];
-        assert.strictEqual(interfaceNode instanceof InterfaceDeclarationSyntaxNode, true, 'is a InterfaceDeclarationSyntaxNode');
+        assert.strictEqual(interfaceNode instanceof InterfaceDeclarationSyntaxNode, true, 'InterfaceDeclarationSyntaxNode');
         let interfaces = interfaceNode.baseInterfaces ? interfaceNode.baseInterfaces.childNodes() : [];
         assert.strictEqual(interfaces.length, 1);
         assert.strictEqual(interfaces[0] instanceof PartiallyQualifiedNameSyntaxNode, true);
@@ -149,7 +149,7 @@ describe('PhpParser', function() {
       }),
       new ParserTestArgs('interface A extends B, C {}', 'should parse an interface declaration with multiple base types', (statements) => {
         let interfaceNode = <InterfaceDeclarationSyntaxNode>statements[0];
-        assert.strictEqual(interfaceNode instanceof InterfaceDeclarationSyntaxNode, true, 'is a InterfaceDeclarationSyntaxNode');
+        assert.strictEqual(interfaceNode instanceof InterfaceDeclarationSyntaxNode, true, 'InterfaceDeclarationSyntaxNode');
         let interfaces = interfaceNode.baseInterfaces ? interfaceNode.baseInterfaces.childNodes() : [];
         assert.strictEqual(interfaces.length, 2);
         assert.strictEqual(interfaces[0] instanceof PartiallyQualifiedNameSyntaxNode, true);
@@ -158,7 +158,7 @@ describe('PhpParser', function() {
       }),
       new ParserTestArgs('interface A extends \\B {}', 'should parse an interface declaration with fully qualified base type', (statements) => {
         let interfaceNode = <InterfaceDeclarationSyntaxNode>statements[0];
-        assert.strictEqual(interfaceNode instanceof InterfaceDeclarationSyntaxNode, true, 'is a InterfaceDeclarationSyntaxNode');
+        assert.strictEqual(interfaceNode instanceof InterfaceDeclarationSyntaxNode, true, 'InterfaceDeclarationSyntaxNode');
         let interfaces = interfaceNode.baseInterfaces ? interfaceNode.baseInterfaces.childNodes() : [];
         assert.strictEqual(interfaces.length, 1);
         assert.strictEqual(interfaces[0] instanceof FullyQualifiedNameSyntaxNode, true);
@@ -166,7 +166,7 @@ describe('PhpParser', function() {
       }),
       new ParserTestArgs('interface A extends namespace\\B {}', 'should parse an interface declaration with relative base type', (statements) => {
         let interfaceNode = <InterfaceDeclarationSyntaxNode>statements[0];
-        assert.strictEqual(interfaceNode instanceof InterfaceDeclarationSyntaxNode, true, 'is a InterfaceDeclarationSyntaxNode');
+        assert.strictEqual(interfaceNode instanceof InterfaceDeclarationSyntaxNode, true, 'InterfaceDeclarationSyntaxNode');
         let interfaces = interfaceNode.baseInterfaces ? interfaceNode.baseInterfaces.childNodes() : [];
         assert.strictEqual(interfaces.length, 1);
         assert.strictEqual(interfaces[0] instanceof RelativeNameSyntaxNode, true);

--- a/test/src/parser/PhpParserTest_InterfaceDeclaration.ts
+++ b/test/src/parser/PhpParserTest_InterfaceDeclaration.ts
@@ -242,20 +242,6 @@ describe('PhpParser', function() {
       Test.assertDiagnostics(featureClassConstantModifiers, PhpVersion.PHP7_0, PhpVersion.PHP7_0);
     });
 
-    describe('property-declaration', function() {
-      let diagnosticTests = [
-        new DiagnosticTestArgs('interface A { abstract $b; }', 'should not parse an abstract property', [ErrorCode.ERR_BadInterfaceModifier, ErrorCode.ERR_InterfaceProperty], [14, 23]),
-        new DiagnosticTestArgs('interface A { final $b; }', 'should not parse a final property', [ErrorCode.ERR_BadInterfaceModifier, ErrorCode.ERR_InterfaceProperty], [14, 20]),
-        new DiagnosticTestArgs('interface A { public $b; }', 'should not parse a public property', [ErrorCode.ERR_InterfaceProperty], [21]),
-        new DiagnosticTestArgs('interface A { protected $b; }', 'should not parse a protected property', [ErrorCode.ERR_InterfaceMemberNotPublic, ErrorCode.ERR_InterfaceProperty], [14, 24]),
-        new DiagnosticTestArgs('interface A { private $b; }', 'should not parse a private property', [ErrorCode.ERR_InterfaceMemberNotPublic, ErrorCode.ERR_InterfaceProperty], [14, 22]),
-        new DiagnosticTestArgs('interface A { static $b; }', 'should not parse a static property', [ErrorCode.ERR_InterfaceProperty], [21]),
-        // For consistency, defer this error to the variable instead of 'var'.
-        new DiagnosticTestArgs('interface A { var $b; }', 'should not parse a var property', [ErrorCode.ERR_InterfaceProperty], [18]),
-      ];
-      Test.assertDiagnostics(diagnosticTests);
-    });
-
     // Everything except for the parameter list and statement block needs full
     // testing since it uses a different implementation than `function-declaration`.
     describe('method-declaration', function() {
@@ -418,6 +404,20 @@ describe('PhpParser', function() {
         new DiagnosticTestArgs('interface A { static final function b(); }', 'should not expect static and final modifiers', [ErrorCode.ERR_BadInterfaceModifier], [21]),
         new DiagnosticTestArgs('interface A { static protected function b(); }', 'should not expect static and protected modifiers', [ErrorCode.ERR_InterfaceMemberNotPublic], [21]),
         new DiagnosticTestArgs('interface A { static private function b(); }', 'should not expect static and private modifiers', [ErrorCode.ERR_InterfaceMemberNotPublic], [21]),
+      ];
+      Test.assertDiagnostics(diagnosticTests);
+    });
+
+    describe('property-declaration', function() {
+      let diagnosticTests = [
+        new DiagnosticTestArgs('interface A { abstract $b; }', 'should not parse an abstract property', [ErrorCode.ERR_BadInterfaceModifier, ErrorCode.ERR_InterfaceProperty], [14, 23]),
+        new DiagnosticTestArgs('interface A { final $b; }', 'should not parse a final property', [ErrorCode.ERR_BadInterfaceModifier, ErrorCode.ERR_InterfaceProperty], [14, 20]),
+        new DiagnosticTestArgs('interface A { public $b; }', 'should not parse a public property', [ErrorCode.ERR_InterfaceProperty], [21]),
+        new DiagnosticTestArgs('interface A { protected $b; }', 'should not parse a protected property', [ErrorCode.ERR_InterfaceMemberNotPublic, ErrorCode.ERR_InterfaceProperty], [14, 24]),
+        new DiagnosticTestArgs('interface A { private $b; }', 'should not parse a private property', [ErrorCode.ERR_InterfaceMemberNotPublic, ErrorCode.ERR_InterfaceProperty], [14, 22]),
+        new DiagnosticTestArgs('interface A { static $b; }', 'should not parse a static property', [ErrorCode.ERR_InterfaceProperty], [21]),
+        // For consistency, defer this error to the variable instead of 'var'.
+        new DiagnosticTestArgs('interface A { var $b; }', 'should not parse a var property', [ErrorCode.ERR_InterfaceProperty], [18]),
       ];
       Test.assertDiagnostics(diagnosticTests);
     });

--- a/test/src/parser/PhpParserTest_Statements.ts
+++ b/test/src/parser/PhpParserTest_Statements.ts
@@ -491,7 +491,8 @@ describe('PhpParser', function() {
     Test.assertDiagnostics(diagnosticTests7_3, PhpVersion.PHP7_3);
 
     let featureTrailingCommas = [
-      new DiagnosticTestArgs('unset($a,);', 'should not parse trailing comma in argument list', [ErrorCode.ERR_FeatureTrailingCommasInArgumentLists], [8]),
+      new DiagnosticTestArgs('unset($a,', 'should not parse trailing comma in argument list', [ErrorCode.ERR_FeatureTrailingCommasInArgumentLists, ErrorCode.ERR_ExpressionOrCloseParenExpected], [8, 9]),
+      new DiagnosticTestArgs('unset($a,);', 'should not parse trailing comma in argument list (completed)', [ErrorCode.ERR_FeatureTrailingCommasInArgumentLists], [8]),
       new DiagnosticTestArgs('unset($a, $b,);', 'should not parse trailing comma in argument list (multiple arguments)', [ErrorCode.ERR_FeatureTrailingCommasInArgumentLists], [12]),
     ];
     Test.assertDiagnostics(featureTrailingCommas, PhpVersion.PHP7_0, PhpVersion.PHP7_2);

--- a/test/src/parser/PhpParserTest_Statements.ts
+++ b/test/src/parser/PhpParserTest_Statements.ts
@@ -59,6 +59,16 @@ import { TokenKind } from '../../../src/language/TokenKind';
 
 describe('PhpParser', function() {
 
+  // class-declaration (see PhpParserTest_ClassDeclaration.ts)
+
+  // function-definition (see PhpParserTest_FunctionDeclaration.ts)
+
+  // interface-declaration (see PhpParserTest_InterfaceDeclaration.ts)
+
+  // trait-declaration (see PhpParserTest_TraitDeclaration.ts)
+
+  // use-declaration (see PhpParserTest_UseDeclaration.ts)
+
   describe('compound-statement', function() {
     let syntaxTests = [
       new ParserTestArgs('{}', 'should parse a compound statement', (statements) => {
@@ -84,17 +94,163 @@ describe('PhpParser', function() {
     Test.assertDiagnostics(diagnosticTests);
   });
 
-  describe('named-label-statement', function() {
+  describe('const-declaration', function() {
     let syntaxTests = [
-      new ParserTestArgs('label:', 'should parse a label statement', (statements, text) => {
-        let labelNode = <LabelSyntaxNode>statements[0];
-        assert.strictEqual(labelNode instanceof LabelSyntaxNode, true, 'LabelSyntaxNode');
-        Test.assertSyntaxToken(labelNode.label, text, TokenKind.Identifier, 'label');
+      new ParserTestArgs('const A=1;', 'should parse a constant declaration', (statements, text) => {
+        let constDecl = <ConstantDeclarationSyntaxNode>statements[0];
+        assert.strictEqual(constDecl instanceof ConstantDeclarationSyntaxNode, true, 'ConstantDeclarationSyntaxNode');
+        let elements = constDecl.elements ? constDecl.elements.childNodes() : [];
+        assert.strictEqual(elements.length, 1);
+        let constNode = <ConstantElementSyntaxNode>elements[0];
+        assert.strictEqual(constNode instanceof ConstantElementSyntaxNode, true);
+        Test.assertSyntaxToken(constNode.identifier, text, TokenKind.Identifier, 'A');
+        assert.strictEqual(constNode.expression instanceof LiteralSyntaxNode, true);
+      }),
+      new ParserTestArgs('const A=1, B=2;', 'should parse multiple constant declarations', (statements, text) => {
+        let constDecl = <ConstantDeclarationSyntaxNode>statements[0];
+        assert.strictEqual(constDecl instanceof ConstantDeclarationSyntaxNode, true, 'ConstantDeclarationSyntaxNode');
+        let elements = constDecl.elements ? constDecl.elements.childNodes() : [];
+        assert.strictEqual(elements.length, 2);
+        let firstConst = <ConstantElementSyntaxNode>elements[0];
+        assert.strictEqual(firstConst instanceof ConstantElementSyntaxNode, true);
+        Test.assertSyntaxToken(firstConst.identifier, text, TokenKind.Identifier, 'A');
+        assert.strictEqual(firstConst.expression instanceof LiteralSyntaxNode, true);
+        let secondConst = <ConstantElementSyntaxNode>elements[1];
+        assert.strictEqual(secondConst instanceof ConstantElementSyntaxNode, true);
+        Test.assertSyntaxToken(secondConst.identifier, text, TokenKind.Identifier, 'B');
+        assert.strictEqual(secondConst.expression instanceof LiteralSyntaxNode, true);
+      })
+    ];
+    Test.assertSyntaxNodes(syntaxTests);
+
+    let diagnosticTests = [
+      new DiagnosticTestArgs('const', 'missing identifier', [ErrorCode.ERR_IdentifierExpected], [5]),
+      new DiagnosticTestArgs('const A', 'missing assignment', [ErrorCode.ERR_Syntax], [7]),
+      new DiagnosticTestArgs('const A=', 'missing expression (EOF)', [ErrorCode.ERR_ExpressionExpectedEOF], [8]),
+      new DiagnosticTestArgs('const A=;', 'missing expression', [ErrorCode.ERR_ExpressionExpected], [8]),
+      new DiagnosticTestArgs('const A=1', 'missing comma or semicolon', [ErrorCode.ERR_CommaOrSemicolonExpected], [9]),
+      new DiagnosticTestArgs('const A=1,', 'missing identifier after comma', [ErrorCode.ERR_IdentifierExpected], [10]),
+    ];
+    Test.assertDiagnostics(diagnosticTests);
+  });
+
+  describe('declare-statement', function() {
+    let syntaxTests = [
+      new ParserTestArgs('declare(a=1);', 'should parse a declare statement', (statements) => {
+        let declareNode = <DeclareSyntaxNode>statements[0];
+        assert.strictEqual(declareNode instanceof DeclareSyntaxNode, true, 'DeclareSyntaxNode');
+        let directives = declareNode.directives;
+        assert.strictEqual(declareNode.directives instanceof SyntaxList, true);
+        let constants = directives ? directives.childNodes() : [];
+        assert.strictEqual(constants.length, 1);
+        assert.strictEqual(constants[0] instanceof ConstantElementSyntaxNode, true);
+        assert.strictEqual(declareNode.statement instanceof ExpressionStatementSyntaxNode, true);
+      }),
+      new ParserTestArgs('declare(a=1, b=2);', 'should parse a declare statement with multiple directives', (statements) => {
+        let declareNode = <DeclareSyntaxNode>statements[0];
+        assert.strictEqual(declareNode instanceof DeclareSyntaxNode, true, 'DeclareSyntaxNode');
+        let directives = declareNode.directives;
+        assert.strictEqual(declareNode.directives instanceof SyntaxList, true);
+        let constants = directives ? directives.childNodes() : [];
+        assert.strictEqual(constants.length, 2);
+        assert.strictEqual(constants[0] instanceof ConstantElementSyntaxNode, true);
+        assert.strictEqual(constants[1] instanceof ConstantElementSyntaxNode, true);
+        assert.strictEqual(declareNode.statement instanceof ExpressionStatementSyntaxNode, true);
+      }),
+      new ParserTestArgs('declare(a=1): enddeclare;', 'should parse a declare statement (alternate syntax)', (statements) => {
+        let declareNode = <DeclareBlockSyntaxNode>statements[0];
+        assert.strictEqual(declareNode instanceof DeclareBlockSyntaxNode, true, 'DeclareBlockSyntaxNode');
+        let directives = declareNode.directives;
+        assert.strictEqual(declareNode.directives instanceof SyntaxList, true);
+        let constants = directives ? directives.childNodes() : [];
+        assert.strictEqual(constants.length, 1);
+        assert.strictEqual(constants[0] instanceof ConstantElementSyntaxNode, true);
+        assert.strictEqual(declareNode.statements, null);
+      }),
+      new ParserTestArgs('declare(a=1): 1; 2; enddeclare;', 'should parse a declare statement with child statements (alternate syntax)', (statements) => {
+        let declareNode = <DeclareBlockSyntaxNode>statements[0];
+        assert.strictEqual(declareNode instanceof DeclareBlockSyntaxNode, true, 'DeclareBlockSyntaxNode');
+        let directives = declareNode.directives;
+        assert.strictEqual(declareNode.directives instanceof SyntaxList, true);
+        let constants = directives ? directives.childNodes() : [];
+        assert.strictEqual(constants.length, 1);
+        assert.strictEqual(constants[0] instanceof ConstantElementSyntaxNode, true);
+        assert.notStrictEqual(declareNode.statements, null);
       }),
     ];
     Test.assertSyntaxNodes(syntaxTests);
 
-    // There are no diagnostics because an identifier without a colon is a constant.
+    // NOTE: See `const-declaration` for assignment tests.
+    let diagnosticTests = [
+      new DiagnosticTestArgs('declare', 'missing open paren', [ErrorCode.ERR_OpenParenExpected], [7]),
+      new DiagnosticTestArgs('declare(', 'missing constant declaration', [ErrorCode.ERR_IdentifierExpected], [8]),
+      new DiagnosticTestArgs('declare(a=1', 'missing comma or close paren', [ErrorCode.ERR_CommaOrCloseParenExpected], [11]),
+      new DiagnosticTestArgs('declare(a=1)', 'missing statement or colon', [ErrorCode.ERR_StatementOrColonExpected], [12]),
+      new DiagnosticTestArgs('declare(a=1):', 'missing enddeclare', [ErrorCode.ERR_Syntax], [13]),
+      new DiagnosticTestArgs('declare(a=1): enddeclare', 'missing semicolon', [ErrorCode.ERR_SemicolonExpected], [24]),
+    ];
+    Test.assertDiagnostics(diagnosticTests);
+  });
+
+  describe('echo-statement', function() {
+    let syntaxTests = [
+      new ParserTestArgs('echo 1;', 'should parse an echo statement', (statements) => {
+        let echoNode = <EchoSyntaxNode>statements[0];
+        assert.strictEqual(echoNode instanceof EchoSyntaxNode, true, 'EchoSyntaxNode');
+        let expressions = echoNode.expressionList.childNodes();
+        assert.strictEqual(expressions.length, 1);
+        assert.strictEqual(expressions[0] instanceof LiteralSyntaxNode, true);
+      }),
+      new ParserTestArgs('echo 1, $a;', 'should parse an echo statement with multiple expressions', (statements) => {
+        let echoNode = <EchoSyntaxNode>statements[0];
+        assert.strictEqual(echoNode instanceof EchoSyntaxNode, true, 'EchoSyntaxNode');
+        let expressions = echoNode.expressionList.childNodes();
+        assert.strictEqual(expressions.length, 2);
+        assert.strictEqual(expressions[0] instanceof LiteralSyntaxNode, true);
+        assert.strictEqual(expressions[1] instanceof LocalVariableSyntaxNode, true);
+      }),
+    ];
+    Test.assertSyntaxNodes(syntaxTests);
+
+    let diagnosticTests = [
+      new DiagnosticTestArgs('echo', 'missing expression', [ErrorCode.ERR_ExpressionExpectedEOF], [4]),
+      new DiagnosticTestArgs('echo $a', 'missing comma or semicolon', [ErrorCode.ERR_CommaOrSemicolonExpected], [7]),
+      new DiagnosticTestArgs('echo $a,', 'missing expression after comma', [ErrorCode.ERR_ExpressionExpectedEOF], [8]),
+    ];
+    Test.assertDiagnostics(diagnosticTests);
+  });
+
+  describe('echo-statement (open tag with echo)', function() {
+    let syntaxTests = [
+      new ParserTestArgs('1;', 'should parse an echo statement', (statements, text) => {
+        let echoNode = <EchoSyntaxNode>statements[0];
+        assert.strictEqual(echoNode instanceof EchoSyntaxNode, true, 'EchoSyntaxNode');
+        Test.assertSyntaxToken(echoNode.echoKeyword, text, TokenKind.OpenTagWithEcho, '<?=');
+        let expressions = echoNode.expressionList.childNodes();
+        assert.strictEqual(expressions.length, 1);
+        assert.strictEqual(expressions[0] instanceof LiteralSyntaxNode, true);
+      }),
+      new ParserTestArgs('1, $a;', 'should parse an echo statement with multiple expressions', (statements, text) => {
+        let echoNode = <EchoSyntaxNode>statements[0];
+        assert.strictEqual(echoNode instanceof EchoSyntaxNode, true, 'EchoSyntaxNode');
+        Test.assertSyntaxToken(echoNode.echoKeyword, text, TokenKind.OpenTagWithEcho, '<?=');
+        let expressions = echoNode.expressionList.childNodes();
+        assert.strictEqual(expressions.length, 2);
+        assert.strictEqual(expressions[0] instanceof LiteralSyntaxNode, true);
+        assert.strictEqual(expressions[1] instanceof LocalVariableSyntaxNode, true);
+      }),
+    ];
+    Test.assertSyntaxNodesWithShortOpen(syntaxTests);
+
+    let diagnosticTests = [
+      // Diagnostic locations are asserted using the entire opening tag, which
+      // is "<?= " in this case. Since the diagnostic should be before the
+      // trailing space, using 4 + -1 gets us to the correct offset.
+      new DiagnosticTestArgs('', 'missing expression', [ErrorCode.ERR_ExpressionExpectedEOF], [-1]),
+      new DiagnosticTestArgs('$a', 'missing comma or semicolon', [ErrorCode.ERR_CommaOrSemicolonExpected], [2]),
+      new DiagnosticTestArgs('$a,', 'missing expression after comma', [ErrorCode.ERR_ExpressionExpectedEOF], [3]),
+    ];
+    Test.assertDiagnosticsWithShortOpen(diagnosticTests);
   });
 
   describe('expression-statement', function() {
@@ -119,6 +275,227 @@ describe('PhpParser', function() {
 
     let diagnosticTests = [
       new DiagnosticTestArgs('1', 'missing semicolon', [ErrorCode.ERR_SemicolonExpected], [1]),
+    ];
+    Test.assertDiagnostics(diagnosticTests);
+  });
+
+  describe('global-declaration', function() {
+    let syntaxTests = [
+      new ParserTestArgs('global $a;', 'should parse a global declaration', (statements) => {
+        let globalDecl = <GlobalSyntaxNode>statements[0];
+        assert.strictEqual(globalDecl instanceof GlobalSyntaxNode, true, 'GlobalSyntaxNode');
+        let variables = globalDecl.variables ? globalDecl.variables.childNodes() : [];
+        assert.strictEqual(variables.length, 1);
+        assert.strictEqual(variables[0] instanceof LocalVariableSyntaxNode, true);
+      }),
+      new ParserTestArgs('global $a, $b;', 'should parse multiple global declarations', (statements) => {
+        let globalDecl = <GlobalSyntaxNode>statements[0];
+        assert.strictEqual(globalDecl instanceof GlobalSyntaxNode, true, 'GlobalSyntaxNode');
+        let variables = globalDecl.variables ? globalDecl.variables.childNodes() : [];
+        assert.strictEqual(variables.length, 2);
+        assert.strictEqual(variables[0] instanceof LocalVariableSyntaxNode, true);
+        assert.strictEqual(variables[1] instanceof LocalVariableSyntaxNode, true);
+      }),
+    ];
+    Test.assertSyntaxNodes(syntaxTests);
+
+    // @todo `global $a $b;` or `global $a $b = 1;`
+
+    let diagnosticTests = [
+      new DiagnosticTestArgs('global', 'missing variable', [ErrorCode.ERR_VariableExpected], [6]),
+      new DiagnosticTestArgs('global $a', 'missing comma or semicolon', [ErrorCode.ERR_CommaOrSemicolonExpected], [9]),
+      new DiagnosticTestArgs('global $a,', 'missing variable in list', [ErrorCode.ERR_VariableExpected], [10]),
+      // Unlike a static declaration, this expects a `simple-variable`.
+      new DiagnosticTestArgs('global $', 'partial variable name', [ErrorCode.ERR_IncompleteVariable], [7]),
+      new DiagnosticTestArgs('global $a=1;', 'should not parse a global declaration with initializer', [ErrorCode.ERR_CommaOrSemicolonExpected], [9]),
+    ];
+    Test.assertDiagnostics(diagnosticTests);
+  });
+
+  describe('halt-compiler-statement', function() {
+    let syntaxTests = [
+      new ParserTestArgs('__halt_compiler();', 'should parse a halt compiler statement', (statements) => {
+        let haltCompiler = <HaltCompilerSyntaxNode>statements[0];
+        assert.strictEqual(haltCompiler instanceof HaltCompilerSyntaxNode, true, 'HaltCompilerSyntaxNode');
+        let root = <SourceTextSyntaxNode>haltCompiler.parent;
+        assert.strictEqual(root instanceof SourceTextSyntaxNode, true, 'SourceTextSyntaxNode');
+        assert.strictEqual(root.eof.fullSpan.length, 0);
+        let semicolon = <ISyntaxToken>root.eof.previousToken(false);
+        assert.notStrictEqual(semicolon, null);
+        assert.strictEqual(semicolon.kind, TokenKind.Semicolon);
+        assert.strictEqual(semicolon.parent, haltCompiler);
+      }),
+      new ParserTestArgs('__halt_compiler(); $a = 1;', 'should parse a halt compiler statement with trailing text', (statements) => {
+        let haltCompiler = <HaltCompilerSyntaxNode>statements[0];
+        assert.strictEqual(haltCompiler instanceof HaltCompilerSyntaxNode, true, 'HaltCompilerSyntaxNode');
+        let root = <SourceTextSyntaxNode>haltCompiler.parent;
+        assert.strictEqual(root instanceof SourceTextSyntaxNode, true, 'SourceTextSyntaxNode');
+        assert.strictEqual(root.eof.fullSpan.length, 8);
+        let semicolon = <ISyntaxToken>root.eof.previousToken(false);
+        assert.notStrictEqual(semicolon, null);
+        assert.strictEqual(semicolon.kind, TokenKind.Semicolon);
+        assert.strictEqual(semicolon.parent, haltCompiler);
+      }),
+    ];
+    Test.assertSyntaxNodes(syntaxTests);
+
+    let diagnosticTests = [
+      new DiagnosticTestArgs('__halt_compiler', 'missing open paren', [ErrorCode.ERR_OpenParenExpected], [15]),
+      new DiagnosticTestArgs('__halt_compiler(', 'missing close paren', [ErrorCode.ERR_CloseParenExpected], [16]),
+      new DiagnosticTestArgs('{ __halt_compiler(); }', 'should not parse an embedded halt compiler statement', [ErrorCode.ERR_HaltCompilerScope], [2]),
+    ];
+    Test.assertDiagnostics(diagnosticTests);
+  });
+
+  describe('named-label-statement', function() {
+    let syntaxTests = [
+      new ParserTestArgs('label:', 'should parse a label statement', (statements, text) => {
+        let labelNode = <LabelSyntaxNode>statements[0];
+        assert.strictEqual(labelNode instanceof LabelSyntaxNode, true, 'LabelSyntaxNode');
+        Test.assertSyntaxToken(labelNode.label, text, TokenKind.Identifier, 'label');
+      }),
+    ];
+    Test.assertSyntaxNodes(syntaxTests);
+
+    // There are no diagnostics because an identifier without a colon is a constant.
+  });
+
+  // Officially this is `namespace-definition`.
+  describe('namespace-declaration', function() {
+    let syntaxTests = [
+      new ParserTestArgs('namespace A;', 'should parse a namespace declaration', (statements) => {
+        let decl = <NamespaceDeclarationSyntaxNode>statements[0];
+        assert.strictEqual(decl instanceof NamespaceDeclarationSyntaxNode, true, 'NamespaceDeclarationSyntaxNode');
+        assert.strictEqual(decl.name instanceof PartiallyQualifiedNameSyntaxNode, true);
+      }),
+      new ParserTestArgs('namespace A\\B;', 'should parse a namespace declaration with multiple names', (statements) => {
+        let decl = <NamespaceDeclarationSyntaxNode>statements[0];
+        assert.strictEqual(decl instanceof NamespaceDeclarationSyntaxNode, true, 'NamespaceDeclarationSyntaxNode');
+        assert.strictEqual(decl.name instanceof PartiallyQualifiedNameSyntaxNode, true);
+      }),
+      new ParserTestArgs('namespace A {}', 'should parse a namespace group declaration', (statements) => {
+        let decl = <NamespaceGroupDeclarationSyntaxNode>statements[0];
+        assert.strictEqual(decl instanceof NamespaceGroupDeclarationSyntaxNode, true, 'NamespaceGroupDeclarationSyntaxNode');
+        assert.strictEqual(decl.name instanceof PartiallyQualifiedNameSyntaxNode, true);
+        assert.strictEqual(decl.statements, null);
+      }),
+      new ParserTestArgs('namespace A\\B {}', 'should parse a namespace group declaration with multiple names', (statements) => {
+        let decl = <NamespaceGroupDeclarationSyntaxNode>statements[0];
+        assert.strictEqual(decl instanceof NamespaceGroupDeclarationSyntaxNode, true, 'NamespaceGroupDeclarationSyntaxNode');
+        assert.strictEqual(decl.name instanceof PartiallyQualifiedNameSyntaxNode, true);
+        assert.strictEqual(decl.statements, null);
+      }),
+      new ParserTestArgs('namespace A { ; }', 'should parse a namespace group declaration with child statement', (statements) => {
+        let decl = <NamespaceGroupDeclarationSyntaxNode>statements[0];
+        assert.strictEqual(decl instanceof NamespaceGroupDeclarationSyntaxNode, true, 'NamespaceGroupDeclarationSyntaxNode');
+        assert.strictEqual(decl.name instanceof PartiallyQualifiedNameSyntaxNode, true);
+        let children = decl.statements ? decl.statements.childNodes() : [];
+        assert.strictEqual(children.length, 1);
+        assert.strictEqual(children[0] instanceof ExpressionStatementSyntaxNode, true);
+      }),
+      new ParserTestArgs('namespace {}', 'should parse a global namespace declaration', (statements) => {
+        let decl = <NamespaceGroupDeclarationSyntaxNode>statements[0];
+        assert.strictEqual(decl instanceof NamespaceGroupDeclarationSyntaxNode, true, 'NamespaceGroupDeclarationSyntaxNode');
+        assert.strictEqual(decl.name, null);
+      }),
+      new ParserTestArgs('namespace { ; }', 'should parse a global namespace declaration with child statement', (statements) => {
+        let decl = <NamespaceGroupDeclarationSyntaxNode>statements[0];
+        assert.strictEqual(decl instanceof NamespaceGroupDeclarationSyntaxNode, true, 'NamespaceGroupDeclarationSyntaxNode');
+        assert.strictEqual(decl.name, null);
+        let children = decl.statements ? decl.statements.childNodes() : [];
+        assert.strictEqual(children.length, 1);
+        assert.strictEqual(children[0] instanceof ExpressionStatementSyntaxNode, true);
+      }),
+    ];
+    Test.assertSyntaxNodes(syntaxTests);
+
+    let diagnosticTests = [
+      new DiagnosticTestArgs('namespace', 'missing name', [ErrorCode.ERR_IncompleteNamespace], [9]),
+      new DiagnosticTestArgs('namespace A', 'missing semicolon or open brace', [ErrorCode.ERR_OpenBraceOrSemicolonExpected], [11]),
+      new DiagnosticTestArgs('namespace A {', 'missing close brace', [ErrorCode.ERR_CloseBraceExpected], [13]),
+      new DiagnosticTestArgs('namespace A { namespace B; }', 'should not parse a nested namespace', [ErrorCode.ERR_NamespaceIsNested], [14]),
+      new DiagnosticTestArgs('namespace A { namespace B {} }', 'should not parse a nested namespace group', [ErrorCode.ERR_NamespaceIsNested], [14]),
+    ];
+    Test.assertDiagnostics(diagnosticTests);
+  });
+
+  describe('static-declaration', function() {
+    let syntaxTests = [
+      new ParserTestArgs('static $a;', 'should parse a static declaration', (statements, text) => {
+        let staticDecl = <StaticSyntaxNode>statements[0];
+        assert.strictEqual(staticDecl instanceof StaticSyntaxNode, true, 'StaticSyntaxNode');
+        let variables = staticDecl.variables ? staticDecl.variables.childNodes() : [];
+        assert.strictEqual(variables.length, 1);
+        let staticVariable = <StaticElementSyntaxNode>variables[0];
+        assert.strictEqual(staticVariable instanceof StaticElementSyntaxNode, true);
+        Test.assertSyntaxToken(staticVariable.variable, text, TokenKind.Variable, '$a');
+        assert.strictEqual(staticVariable.expression, null);
+      }),
+      new ParserTestArgs('static $a=1;', 'should parse a static declaration with initializer', (statements, text) => {
+        let staticDecl = <StaticSyntaxNode>statements[0];
+        assert.strictEqual(staticDecl instanceof StaticSyntaxNode, true, 'StaticSyntaxNode');
+        let variables = staticDecl.variables ? staticDecl.variables.childNodes() : [];
+        assert.strictEqual(variables.length, 1);
+        let staticVariable = <StaticElementSyntaxNode>variables[0];
+        assert.strictEqual(staticVariable instanceof StaticElementSyntaxNode, true);
+        Test.assertSyntaxToken(staticVariable.variable, text, TokenKind.Variable, '$a');
+        assert.strictEqual(staticVariable.expression instanceof LiteralSyntaxNode, true);
+      }),
+      new ParserTestArgs('static $a, $b;', 'should parse multiple static declarations', (statements, text) => {
+        let staticDecl = <StaticSyntaxNode>statements[0];
+        assert.strictEqual(staticDecl instanceof StaticSyntaxNode, true, 'StaticSyntaxNode');
+        let variables = staticDecl.variables ? staticDecl.variables.childNodes() : [];
+        assert.strictEqual(variables.length, 2);
+        let firstVariable = <StaticElementSyntaxNode>variables[0];
+        assert.strictEqual(firstVariable instanceof StaticElementSyntaxNode, true);
+        Test.assertSyntaxToken(firstVariable.variable, text, TokenKind.Variable, '$a');
+        assert.strictEqual(firstVariable.expression, null);
+        let secondVariable = <StaticElementSyntaxNode>variables[1];
+        assert.strictEqual(secondVariable instanceof StaticElementSyntaxNode, true);
+        Test.assertSyntaxToken(secondVariable.variable, text, TokenKind.Variable, '$b');
+        assert.strictEqual(secondVariable.expression, null);
+      }),
+      new ParserTestArgs('static $a=1, $b;', 'should parse multiple static declarations (first with initializer)', (statements, text) => {
+        let staticDecl = <StaticSyntaxNode>statements[0];
+        assert.strictEqual(staticDecl instanceof StaticSyntaxNode, true, 'StaticSyntaxNode');
+        let variables = staticDecl.variables ? staticDecl.variables.childNodes() : [];
+        assert.strictEqual(variables.length, 2);
+        let firstVariable = <StaticElementSyntaxNode>variables[0];
+        assert.strictEqual(firstVariable instanceof StaticElementSyntaxNode, true);
+        Test.assertSyntaxToken(firstVariable.variable, text, TokenKind.Variable, '$a');
+        assert.strictEqual(firstVariable.expression instanceof LiteralSyntaxNode, true);
+        let secondVariable = <StaticElementSyntaxNode>variables[1];
+        assert.strictEqual(secondVariable instanceof StaticElementSyntaxNode, true);
+        Test.assertSyntaxToken(secondVariable.variable, text, TokenKind.Variable, '$b');
+        assert.strictEqual(secondVariable.expression, null);
+      }),
+      new ParserTestArgs('static $a, $b=2;', 'should parse multiple static declarations (second with initializer)', (statements, text) => {
+        let staticDecl = <StaticSyntaxNode>statements[0];
+        assert.strictEqual(staticDecl instanceof StaticSyntaxNode, true, 'StaticSyntaxNode');
+        let variables = staticDecl.variables ? staticDecl.variables.childNodes() : [];
+        assert.strictEqual(variables.length, 2);
+        let firstVariable = <StaticElementSyntaxNode>variables[0];
+        assert.strictEqual(firstVariable instanceof StaticElementSyntaxNode, true);
+        Test.assertSyntaxToken(firstVariable.variable, text, TokenKind.Variable, '$a');
+        assert.strictEqual(firstVariable.expression, null);
+        let secondVariable = <StaticElementSyntaxNode>variables[1];
+        assert.strictEqual(secondVariable instanceof StaticElementSyntaxNode, true);
+        Test.assertSyntaxToken(secondVariable.variable, text, TokenKind.Variable, '$b');
+        assert.strictEqual(secondVariable.expression instanceof LiteralSyntaxNode, true);
+      }),
+    ];
+    Test.assertSyntaxNodes(syntaxTests);
+
+    // @todo `static $a = 1 $b = 2;`
+
+    let diagnosticTests = [
+      new DiagnosticTestArgs('static', 'missing double colon, function, or variable', [ErrorCode.ERR_StaticExpressionExpected], [6]),
+      new DiagnosticTestArgs('static $a', 'missing equals, comma or semicolon', [ErrorCode.ERR_IncompleteStaticVariableDeclaration], [9]),
+      new DiagnosticTestArgs('static $a=', 'missing expression', [ErrorCode.ERR_ExpressionExpectedEOF], [10]),
+      new DiagnosticTestArgs('static $a=1', 'missing comma or semicolon', [ErrorCode.ERR_CommaOrSemicolonExpected], [11]),
+      new DiagnosticTestArgs('static $a,', 'missing variable in list', [ErrorCode.ERR_VariableExpected], [10]),
+      // Unlike a global declaration, this expects a `VARIABLE` token.
+      new DiagnosticTestArgs('static $', 'partial variable name', [ErrorCode.ERR_VariableNameExpected], [7]),
     ];
     Test.assertDiagnostics(diagnosticTests);
   });
@@ -305,125 +682,6 @@ describe('PhpParser', function() {
     Test.assertDiagnostics(diagnosticRegressionTests8_0, PhpVersion.PHP7_0, PhpVersion.PHP7_4);
   });
 
-  describe('declare-statement', function() {
-    let syntaxTests = [
-      new ParserTestArgs('declare(a=1);', 'should parse a declare statement', (statements) => {
-        let declareNode = <DeclareSyntaxNode>statements[0];
-        assert.strictEqual(declareNode instanceof DeclareSyntaxNode, true, 'DeclareSyntaxNode');
-        let directives = declareNode.directives;
-        assert.strictEqual(declareNode.directives instanceof SyntaxList, true);
-        let constants = directives ? directives.childNodes() : [];
-        assert.strictEqual(constants.length, 1);
-        assert.strictEqual(constants[0] instanceof ConstantElementSyntaxNode, true);
-        assert.strictEqual(declareNode.statement instanceof ExpressionStatementSyntaxNode, true);
-      }),
-      new ParserTestArgs('declare(a=1, b=2);', 'should parse a declare statement with multiple directives', (statements) => {
-        let declareNode = <DeclareSyntaxNode>statements[0];
-        assert.strictEqual(declareNode instanceof DeclareSyntaxNode, true, 'DeclareSyntaxNode');
-        let directives = declareNode.directives;
-        assert.strictEqual(declareNode.directives instanceof SyntaxList, true);
-        let constants = directives ? directives.childNodes() : [];
-        assert.strictEqual(constants.length, 2);
-        assert.strictEqual(constants[0] instanceof ConstantElementSyntaxNode, true);
-        assert.strictEqual(constants[1] instanceof ConstantElementSyntaxNode, true);
-        assert.strictEqual(declareNode.statement instanceof ExpressionStatementSyntaxNode, true);
-      }),
-      new ParserTestArgs('declare(a=1): enddeclare;', 'should parse a declare statement (alternate syntax)', (statements) => {
-        let declareNode = <DeclareBlockSyntaxNode>statements[0];
-        assert.strictEqual(declareNode instanceof DeclareBlockSyntaxNode, true, 'DeclareBlockSyntaxNode');
-        let directives = declareNode.directives;
-        assert.strictEqual(declareNode.directives instanceof SyntaxList, true);
-        let constants = directives ? directives.childNodes() : [];
-        assert.strictEqual(constants.length, 1);
-        assert.strictEqual(constants[0] instanceof ConstantElementSyntaxNode, true);
-        assert.strictEqual(declareNode.statements, null);
-      }),
-      new ParserTestArgs('declare(a=1): 1; 2; enddeclare;', 'should parse a declare statement with child statements (alternate syntax)', (statements) => {
-        let declareNode = <DeclareBlockSyntaxNode>statements[0];
-        assert.strictEqual(declareNode instanceof DeclareBlockSyntaxNode, true, 'DeclareBlockSyntaxNode');
-        let directives = declareNode.directives;
-        assert.strictEqual(declareNode.directives instanceof SyntaxList, true);
-        let constants = directives ? directives.childNodes() : [];
-        assert.strictEqual(constants.length, 1);
-        assert.strictEqual(constants[0] instanceof ConstantElementSyntaxNode, true);
-        assert.notStrictEqual(declareNode.statements, null);
-      }),
-    ];
-    Test.assertSyntaxNodes(syntaxTests);
-
-    // NOTE: See `const-declaration` for assignment tests.
-    let diagnosticTests = [
-      new DiagnosticTestArgs('declare', 'missing open paren', [ErrorCode.ERR_OpenParenExpected], [7]),
-      new DiagnosticTestArgs('declare(', 'missing constant declaration', [ErrorCode.ERR_IdentifierExpected], [8]),
-      new DiagnosticTestArgs('declare(a=1', 'missing comma or close paren', [ErrorCode.ERR_CommaOrCloseParenExpected], [11]),
-      new DiagnosticTestArgs('declare(a=1)', 'missing statement or colon', [ErrorCode.ERR_StatementOrColonExpected], [12]),
-      new DiagnosticTestArgs('declare(a=1):', 'missing enddeclare', [ErrorCode.ERR_Syntax], [13]),
-      new DiagnosticTestArgs('declare(a=1): enddeclare', 'missing semicolon', [ErrorCode.ERR_SemicolonExpected], [24]),
-    ];
-    Test.assertDiagnostics(diagnosticTests);
-  });
-
-  describe('echo-statement', function() {
-    let syntaxTests = [
-      new ParserTestArgs('echo 1;', 'should parse an echo statement', (statements) => {
-        let echoNode = <EchoSyntaxNode>statements[0];
-        assert.strictEqual(echoNode instanceof EchoSyntaxNode, true, 'EchoSyntaxNode');
-        let expressions = echoNode.expressionList.childNodes();
-        assert.strictEqual(expressions.length, 1);
-        assert.strictEqual(expressions[0] instanceof LiteralSyntaxNode, true);
-      }),
-      new ParserTestArgs('echo 1, $a;', 'should parse an echo statement with multiple expressions', (statements) => {
-        let echoNode = <EchoSyntaxNode>statements[0];
-        assert.strictEqual(echoNode instanceof EchoSyntaxNode, true, 'EchoSyntaxNode');
-        let expressions = echoNode.expressionList.childNodes();
-        assert.strictEqual(expressions.length, 2);
-        assert.strictEqual(expressions[0] instanceof LiteralSyntaxNode, true);
-        assert.strictEqual(expressions[1] instanceof LocalVariableSyntaxNode, true);
-      }),
-    ];
-    Test.assertSyntaxNodes(syntaxTests);
-
-    let diagnosticTests = [
-      new DiagnosticTestArgs('echo', 'missing expression', [ErrorCode.ERR_ExpressionExpectedEOF], [4]),
-      new DiagnosticTestArgs('echo $a', 'missing comma or semicolon', [ErrorCode.ERR_CommaOrSemicolonExpected], [7]),
-      new DiagnosticTestArgs('echo $a,', 'missing expression after comma', [ErrorCode.ERR_ExpressionExpectedEOF], [8]),
-    ];
-    Test.assertDiagnostics(diagnosticTests);
-  });
-
-  describe('echo-statement (open tag with echo)', function() {
-    let syntaxTests = [
-      new ParserTestArgs('1;', 'should parse an echo statement', (statements, text) => {
-        let echoNode = <EchoSyntaxNode>statements[0];
-        assert.strictEqual(echoNode instanceof EchoSyntaxNode, true, 'EchoSyntaxNode');
-        Test.assertSyntaxToken(echoNode.echoKeyword, text, TokenKind.OpenTagWithEcho, '<?=');
-        let expressions = echoNode.expressionList.childNodes();
-        assert.strictEqual(expressions.length, 1);
-        assert.strictEqual(expressions[0] instanceof LiteralSyntaxNode, true);
-      }),
-      new ParserTestArgs('1, $a;', 'should parse an echo statement with multiple expressions', (statements, text) => {
-        let echoNode = <EchoSyntaxNode>statements[0];
-        assert.strictEqual(echoNode instanceof EchoSyntaxNode, true, 'EchoSyntaxNode');
-        Test.assertSyntaxToken(echoNode.echoKeyword, text, TokenKind.OpenTagWithEcho, '<?=');
-        let expressions = echoNode.expressionList.childNodes();
-        assert.strictEqual(expressions.length, 2);
-        assert.strictEqual(expressions[0] instanceof LiteralSyntaxNode, true);
-        assert.strictEqual(expressions[1] instanceof LocalVariableSyntaxNode, true);
-      }),
-    ];
-    Test.assertSyntaxNodesWithShortOpen(syntaxTests);
-
-    let diagnosticTests = [
-      // Diagnostic locations are asserted using the entire opening tag, which
-      // is "<?= " in this case. Since the diagnostic should be before the
-      // trailing space, using 4 + -1 gets us to the correct offset.
-      new DiagnosticTestArgs('', 'missing expression', [ErrorCode.ERR_ExpressionExpectedEOF], [-1]),
-      new DiagnosticTestArgs('$a', 'missing comma or semicolon', [ErrorCode.ERR_CommaOrSemicolonExpected], [2]),
-      new DiagnosticTestArgs('$a,', 'missing expression after comma', [ErrorCode.ERR_ExpressionExpectedEOF], [3]),
-    ];
-    Test.assertDiagnosticsWithShortOpen(diagnosticTests);
-  });
-
   describe('unset-statement', function() {
     let syntaxTests = [
       new ParserTestArgs('unset($a);', 'should parse an unset statement', (statements, text) => {
@@ -496,264 +754,6 @@ describe('PhpParser', function() {
       new DiagnosticTestArgs('unset($a, $b,);', 'should not parse trailing comma in argument list (multiple arguments)', [ErrorCode.ERR_FeatureTrailingCommasInArgumentLists], [12]),
     ];
     Test.assertDiagnostics(featureTrailingCommas, PhpVersion.PHP7_0, PhpVersion.PHP7_2);
-  });
-
-  describe('const-declaration', function() {
-    let syntaxTests = [
-      new ParserTestArgs('const A=1;', 'should parse a constant declaration', (statements, text) => {
-        let constDecl = <ConstantDeclarationSyntaxNode>statements[0];
-        assert.strictEqual(constDecl instanceof ConstantDeclarationSyntaxNode, true, 'ConstantDeclarationSyntaxNode');
-        let elements = constDecl.elements ? constDecl.elements.childNodes() : [];
-        assert.strictEqual(elements.length, 1);
-        let constNode = <ConstantElementSyntaxNode>elements[0];
-        assert.strictEqual(constNode instanceof ConstantElementSyntaxNode, true);
-        Test.assertSyntaxToken(constNode.identifier, text, TokenKind.Identifier, 'A');
-        assert.strictEqual(constNode.expression instanceof LiteralSyntaxNode, true);
-      }),
-      new ParserTestArgs('const A=1, B=2;', 'should parse multiple constant declarations', (statements, text) => {
-        let constDecl = <ConstantDeclarationSyntaxNode>statements[0];
-        assert.strictEqual(constDecl instanceof ConstantDeclarationSyntaxNode, true, 'ConstantDeclarationSyntaxNode');
-        let elements = constDecl.elements ? constDecl.elements.childNodes() : [];
-        assert.strictEqual(elements.length, 2);
-        let firstConst = <ConstantElementSyntaxNode>elements[0];
-        assert.strictEqual(firstConst instanceof ConstantElementSyntaxNode, true);
-        Test.assertSyntaxToken(firstConst.identifier, text, TokenKind.Identifier, 'A');
-        assert.strictEqual(firstConst.expression instanceof LiteralSyntaxNode, true);
-        let secondConst = <ConstantElementSyntaxNode>elements[1];
-        assert.strictEqual(secondConst instanceof ConstantElementSyntaxNode, true);
-        Test.assertSyntaxToken(secondConst.identifier, text, TokenKind.Identifier, 'B');
-        assert.strictEqual(secondConst.expression instanceof LiteralSyntaxNode, true);
-      })
-    ];
-    Test.assertSyntaxNodes(syntaxTests);
-
-    let diagnosticTests = [
-      new DiagnosticTestArgs('const', 'missing identifier', [ErrorCode.ERR_IdentifierExpected], [5]),
-      new DiagnosticTestArgs('const A', 'missing assignment', [ErrorCode.ERR_Syntax], [7]),
-      new DiagnosticTestArgs('const A=', 'missing expression (EOF)', [ErrorCode.ERR_ExpressionExpectedEOF], [8]),
-      new DiagnosticTestArgs('const A=;', 'missing expression', [ErrorCode.ERR_ExpressionExpected], [8]),
-      new DiagnosticTestArgs('const A=1', 'missing comma or semicolon', [ErrorCode.ERR_CommaOrSemicolonExpected], [9]),
-      new DiagnosticTestArgs('const A=1,', 'missing identifier after comma', [ErrorCode.ERR_IdentifierExpected], [10]),
-    ];
-    Test.assertDiagnostics(diagnosticTests);
-  });
-
-  // function-definition (see PhpParserTest_FunctionDeclaration.ts)
-
-  // class-declaration (see PhpParserTest_ClassDeclaration.ts)
-
-  // interface-declaration (see PhpParserTest_InterfaceDeclaration.ts)
-
-  // trait-declaration (see PhpParserTest_TraitDeclaration.ts)
-
-  // Officially this is `namespace-definition`.
-  describe('namespace-declaration', function() {
-    let syntaxTests = [
-      new ParserTestArgs('namespace A;', 'should parse a namespace declaration', (statements) => {
-        let decl = <NamespaceDeclarationSyntaxNode>statements[0];
-        assert.strictEqual(decl instanceof NamespaceDeclarationSyntaxNode, true, 'NamespaceDeclarationSyntaxNode');
-        assert.strictEqual(decl.name instanceof PartiallyQualifiedNameSyntaxNode, true);
-      }),
-      new ParserTestArgs('namespace A\\B;', 'should parse a namespace declaration with multiple names', (statements) => {
-        let decl = <NamespaceDeclarationSyntaxNode>statements[0];
-        assert.strictEqual(decl instanceof NamespaceDeclarationSyntaxNode, true, 'NamespaceDeclarationSyntaxNode');
-        assert.strictEqual(decl.name instanceof PartiallyQualifiedNameSyntaxNode, true);
-      }),
-      new ParserTestArgs('namespace A {}', 'should parse a namespace group declaration', (statements) => {
-        let decl = <NamespaceGroupDeclarationSyntaxNode>statements[0];
-        assert.strictEqual(decl instanceof NamespaceGroupDeclarationSyntaxNode, true, 'NamespaceGroupDeclarationSyntaxNode');
-        assert.strictEqual(decl.name instanceof PartiallyQualifiedNameSyntaxNode, true);
-        assert.strictEqual(decl.statements, null);
-      }),
-      new ParserTestArgs('namespace A\\B {}', 'should parse a namespace group declaration with multiple names', (statements) => {
-        let decl = <NamespaceGroupDeclarationSyntaxNode>statements[0];
-        assert.strictEqual(decl instanceof NamespaceGroupDeclarationSyntaxNode, true, 'NamespaceGroupDeclarationSyntaxNode');
-        assert.strictEqual(decl.name instanceof PartiallyQualifiedNameSyntaxNode, true);
-        assert.strictEqual(decl.statements, null);
-      }),
-      new ParserTestArgs('namespace A { ; }', 'should parse a namespace group declaration with child statement', (statements) => {
-        let decl = <NamespaceGroupDeclarationSyntaxNode>statements[0];
-        assert.strictEqual(decl instanceof NamespaceGroupDeclarationSyntaxNode, true, 'NamespaceGroupDeclarationSyntaxNode');
-        assert.strictEqual(decl.name instanceof PartiallyQualifiedNameSyntaxNode, true);
-        let children = decl.statements ? decl.statements.childNodes() : [];
-        assert.strictEqual(children.length, 1);
-        assert.strictEqual(children[0] instanceof ExpressionStatementSyntaxNode, true);
-      }),
-      new ParserTestArgs('namespace {}', 'should parse a global namespace declaration', (statements) => {
-        let decl = <NamespaceGroupDeclarationSyntaxNode>statements[0];
-        assert.strictEqual(decl instanceof NamespaceGroupDeclarationSyntaxNode, true, 'NamespaceGroupDeclarationSyntaxNode');
-        assert.strictEqual(decl.name, null);
-      }),
-      new ParserTestArgs('namespace { ; }', 'should parse a global namespace declaration with child statement', (statements) => {
-        let decl = <NamespaceGroupDeclarationSyntaxNode>statements[0];
-        assert.strictEqual(decl instanceof NamespaceGroupDeclarationSyntaxNode, true, 'NamespaceGroupDeclarationSyntaxNode');
-        assert.strictEqual(decl.name, null);
-        let children = decl.statements ? decl.statements.childNodes() : [];
-        assert.strictEqual(children.length, 1);
-        assert.strictEqual(children[0] instanceof ExpressionStatementSyntaxNode, true);
-      }),
-    ];
-    Test.assertSyntaxNodes(syntaxTests);
-
-    let diagnosticTests = [
-      new DiagnosticTestArgs('namespace', 'missing name', [ErrorCode.ERR_IncompleteNamespace], [9]),
-      new DiagnosticTestArgs('namespace A', 'missing semicolon or open brace', [ErrorCode.ERR_OpenBraceOrSemicolonExpected], [11]),
-      new DiagnosticTestArgs('namespace A {', 'missing close brace', [ErrorCode.ERR_CloseBraceExpected], [13]),
-      new DiagnosticTestArgs('namespace A { namespace B; }', 'should not parse a nested namespace', [ErrorCode.ERR_NamespaceIsNested], [14]),
-      new DiagnosticTestArgs('namespace A { namespace B {} }', 'should not parse a nested namespace group', [ErrorCode.ERR_NamespaceIsNested], [14]),
-    ];
-    Test.assertDiagnostics(diagnosticTests);
-  });
-
-  // use-declaration (see PhpParserTest_UseDeclaration.ts)
-
-  describe('global-declaration', function() {
-    let syntaxTests = [
-      new ParserTestArgs('global $a;', 'should parse a global declaration', (statements) => {
-        let globalDecl = <GlobalSyntaxNode>statements[0];
-        assert.strictEqual(globalDecl instanceof GlobalSyntaxNode, true, 'GlobalSyntaxNode');
-        let variables = globalDecl.variables ? globalDecl.variables.childNodes() : [];
-        assert.strictEqual(variables.length, 1);
-        assert.strictEqual(variables[0] instanceof LocalVariableSyntaxNode, true);
-      }),
-      new ParserTestArgs('global $a, $b;', 'should parse multiple global declarations', (statements) => {
-        let globalDecl = <GlobalSyntaxNode>statements[0];
-        assert.strictEqual(globalDecl instanceof GlobalSyntaxNode, true, 'GlobalSyntaxNode');
-        let variables = globalDecl.variables ? globalDecl.variables.childNodes() : [];
-        assert.strictEqual(variables.length, 2);
-        assert.strictEqual(variables[0] instanceof LocalVariableSyntaxNode, true);
-        assert.strictEqual(variables[1] instanceof LocalVariableSyntaxNode, true);
-      }),
-    ];
-    Test.assertSyntaxNodes(syntaxTests);
-
-    // @todo `global $a $b;` or `global $a $b = 1;`
-
-    let diagnosticTests = [
-      new DiagnosticTestArgs('global', 'missing variable', [ErrorCode.ERR_VariableExpected], [6]),
-      new DiagnosticTestArgs('global $a', 'missing comma or semicolon', [ErrorCode.ERR_CommaOrSemicolonExpected], [9]),
-      new DiagnosticTestArgs('global $a,', 'missing variable in list', [ErrorCode.ERR_VariableExpected], [10]),
-      // Unlike a static declaration, this expects a `simple-variable`.
-      new DiagnosticTestArgs('global $', 'partial variable name', [ErrorCode.ERR_IncompleteVariable], [7]),
-      new DiagnosticTestArgs('global $a=1;', 'should not parse a global declaration with initializer', [ErrorCode.ERR_CommaOrSemicolonExpected], [9]),
-    ];
-    Test.assertDiagnostics(diagnosticTests);
-  });
-
-  describe('static-declaration', function() {
-    let syntaxTests = [
-      new ParserTestArgs('static $a;', 'should parse a static declaration', (statements, text) => {
-        let staticDecl = <StaticSyntaxNode>statements[0];
-        assert.strictEqual(staticDecl instanceof StaticSyntaxNode, true, 'StaticSyntaxNode');
-        let variables = staticDecl.variables ? staticDecl.variables.childNodes() : [];
-        assert.strictEqual(variables.length, 1);
-        let staticVariable = <StaticElementSyntaxNode>variables[0];
-        assert.strictEqual(staticVariable instanceof StaticElementSyntaxNode, true);
-        Test.assertSyntaxToken(staticVariable.variable, text, TokenKind.Variable, '$a');
-        assert.strictEqual(staticVariable.expression, null);
-      }),
-      new ParserTestArgs('static $a=1;', 'should parse a static declaration with initializer', (statements, text) => {
-        let staticDecl = <StaticSyntaxNode>statements[0];
-        assert.strictEqual(staticDecl instanceof StaticSyntaxNode, true, 'StaticSyntaxNode');
-        let variables = staticDecl.variables ? staticDecl.variables.childNodes() : [];
-        assert.strictEqual(variables.length, 1);
-        let staticVariable = <StaticElementSyntaxNode>variables[0];
-        assert.strictEqual(staticVariable instanceof StaticElementSyntaxNode, true);
-        Test.assertSyntaxToken(staticVariable.variable, text, TokenKind.Variable, '$a');
-        assert.strictEqual(staticVariable.expression instanceof LiteralSyntaxNode, true);
-      }),
-      new ParserTestArgs('static $a, $b;', 'should parse multiple static declarations', (statements, text) => {
-        let staticDecl = <StaticSyntaxNode>statements[0];
-        assert.strictEqual(staticDecl instanceof StaticSyntaxNode, true, 'StaticSyntaxNode');
-        let variables = staticDecl.variables ? staticDecl.variables.childNodes() : [];
-        assert.strictEqual(variables.length, 2);
-        let firstVariable = <StaticElementSyntaxNode>variables[0];
-        assert.strictEqual(firstVariable instanceof StaticElementSyntaxNode, true);
-        Test.assertSyntaxToken(firstVariable.variable, text, TokenKind.Variable, '$a');
-        assert.strictEqual(firstVariable.expression, null);
-        let secondVariable = <StaticElementSyntaxNode>variables[1];
-        assert.strictEqual(secondVariable instanceof StaticElementSyntaxNode, true);
-        Test.assertSyntaxToken(secondVariable.variable, text, TokenKind.Variable, '$b');
-        assert.strictEqual(secondVariable.expression, null);
-      }),
-      new ParserTestArgs('static $a=1, $b;', 'should parse multiple static declarations (first with initializer)', (statements, text) => {
-        let staticDecl = <StaticSyntaxNode>statements[0];
-        assert.strictEqual(staticDecl instanceof StaticSyntaxNode, true, 'StaticSyntaxNode');
-        let variables = staticDecl.variables ? staticDecl.variables.childNodes() : [];
-        assert.strictEqual(variables.length, 2);
-        let firstVariable = <StaticElementSyntaxNode>variables[0];
-        assert.strictEqual(firstVariable instanceof StaticElementSyntaxNode, true);
-        Test.assertSyntaxToken(firstVariable.variable, text, TokenKind.Variable, '$a');
-        assert.strictEqual(firstVariable.expression instanceof LiteralSyntaxNode, true);
-        let secondVariable = <StaticElementSyntaxNode>variables[1];
-        assert.strictEqual(secondVariable instanceof StaticElementSyntaxNode, true);
-        Test.assertSyntaxToken(secondVariable.variable, text, TokenKind.Variable, '$b');
-        assert.strictEqual(secondVariable.expression, null);
-      }),
-      new ParserTestArgs('static $a, $b=2;', 'should parse multiple static declarations (second with initializer)', (statements, text) => {
-        let staticDecl = <StaticSyntaxNode>statements[0];
-        assert.strictEqual(staticDecl instanceof StaticSyntaxNode, true, 'StaticSyntaxNode');
-        let variables = staticDecl.variables ? staticDecl.variables.childNodes() : [];
-        assert.strictEqual(variables.length, 2);
-        let firstVariable = <StaticElementSyntaxNode>variables[0];
-        assert.strictEqual(firstVariable instanceof StaticElementSyntaxNode, true);
-        Test.assertSyntaxToken(firstVariable.variable, text, TokenKind.Variable, '$a');
-        assert.strictEqual(firstVariable.expression, null);
-        let secondVariable = <StaticElementSyntaxNode>variables[1];
-        assert.strictEqual(secondVariable instanceof StaticElementSyntaxNode, true);
-        Test.assertSyntaxToken(secondVariable.variable, text, TokenKind.Variable, '$b');
-        assert.strictEqual(secondVariable.expression instanceof LiteralSyntaxNode, true);
-      }),
-    ];
-    Test.assertSyntaxNodes(syntaxTests);
-
-    // @todo `static $a = 1 $b = 2;`
-
-    let diagnosticTests = [
-      new DiagnosticTestArgs('static', 'missing double colon, function, or variable', [ErrorCode.ERR_StaticExpressionExpected], [6]),
-      new DiagnosticTestArgs('static $a', 'missing equals, comma or semicolon', [ErrorCode.ERR_IncompleteStaticVariableDeclaration], [9]),
-      new DiagnosticTestArgs('static $a=', 'missing expression', [ErrorCode.ERR_ExpressionExpectedEOF], [10]),
-      new DiagnosticTestArgs('static $a=1', 'missing comma or semicolon', [ErrorCode.ERR_CommaOrSemicolonExpected], [11]),
-      new DiagnosticTestArgs('static $a,', 'missing variable in list', [ErrorCode.ERR_VariableExpected], [10]),
-      // Unlike a global declaration, this expects a `VARIABLE` token.
-      new DiagnosticTestArgs('static $', 'partial variable name', [ErrorCode.ERR_VariableNameExpected], [7]),
-    ];
-    Test.assertDiagnostics(diagnosticTests);
-  });
-
-  describe('halt-compiler-statement', function() {
-    let syntaxTests = [
-      new ParserTestArgs('__halt_compiler();', 'should parse a halt compiler statement', (statements) => {
-        let haltCompiler = <HaltCompilerSyntaxNode>statements[0];
-        assert.strictEqual(haltCompiler instanceof HaltCompilerSyntaxNode, true, 'HaltCompilerSyntaxNode');
-        let root = <SourceTextSyntaxNode>haltCompiler.parent;
-        assert.strictEqual(root instanceof SourceTextSyntaxNode, true, 'SourceTextSyntaxNode');
-        assert.strictEqual(root.eof.fullSpan.length, 0);
-        let semicolon = <ISyntaxToken>root.eof.previousToken(false);
-        assert.notStrictEqual(semicolon, null);
-        assert.strictEqual(semicolon.kind, TokenKind.Semicolon);
-        assert.strictEqual(semicolon.parent, haltCompiler);
-      }),
-      new ParserTestArgs('__halt_compiler(); $a = 1;', 'should parse a halt compiler statement with trailing text', (statements) => {
-        let haltCompiler = <HaltCompilerSyntaxNode>statements[0];
-        assert.strictEqual(haltCompiler instanceof HaltCompilerSyntaxNode, true, 'HaltCompilerSyntaxNode');
-        let root = <SourceTextSyntaxNode>haltCompiler.parent;
-        assert.strictEqual(root instanceof SourceTextSyntaxNode, true, 'SourceTextSyntaxNode');
-        assert.strictEqual(root.eof.fullSpan.length, 8);
-        let semicolon = <ISyntaxToken>root.eof.previousToken(false);
-        assert.notStrictEqual(semicolon, null);
-        assert.strictEqual(semicolon.kind, TokenKind.Semicolon);
-        assert.strictEqual(semicolon.parent, haltCompiler);
-      }),
-    ];
-    Test.assertSyntaxNodes(syntaxTests);
-
-    let diagnosticTests = [
-      new DiagnosticTestArgs('__halt_compiler', 'missing open paren', [ErrorCode.ERR_OpenParenExpected], [15]),
-      new DiagnosticTestArgs('__halt_compiler(', 'missing close paren', [ErrorCode.ERR_CloseParenExpected], [16]),
-      new DiagnosticTestArgs('{ __halt_compiler(); }', 'should not parse an embedded halt compiler statement', [ErrorCode.ERR_HaltCompilerScope], [2]),
-    ];
-    Test.assertDiagnostics(diagnosticTests);
   });
 
 });

--- a/test/src/parser/PhpParserTest_Statements_Iteration.ts
+++ b/test/src/parser/PhpParserTest_Statements_Iteration.ts
@@ -66,42 +66,6 @@ describe('PhpParser', function() {
 
   describe('iteration-statement', function() {
 
-    describe('while-statement', function() {
-      let syntaxTests = [
-        new ParserTestArgs('while ($a) 1;', 'should parse a while statement', (statements) => {
-          let whileNode = <WhileSyntaxNode>statements[0];
-          assert.strictEqual(whileNode instanceof WhileSyntaxNode, true, 'is a WhileSyntaxNode');
-          assert.strictEqual(whileNode.condition instanceof LocalVariableSyntaxNode, true);
-          assert.strictEqual(whileNode.statement instanceof ExpressionStatementSyntaxNode, true);
-        }),
-        new ParserTestArgs('while ($a): endwhile;', 'should parse a while statement (alternate syntax)', (statements) => {
-          let whileNode = <WhileBlockSyntaxNode>statements[0];
-          assert.strictEqual(whileNode instanceof WhileBlockSyntaxNode, true, 'is a WhileBlockSyntaxNode');
-          assert.strictEqual(whileNode.condition instanceof LocalVariableSyntaxNode, true);
-          assert.strictEqual(whileNode.statements, null);
-        }),
-        new ParserTestArgs('while ($a): 1; endwhile;', 'should parse a while statement (alternate syntax; with child statement)', (statements) => {
-          let whileNode = <WhileBlockSyntaxNode>statements[0];
-          assert.strictEqual(whileNode instanceof WhileBlockSyntaxNode, true, 'is a WhileBlockSyntaxNode');
-          assert.strictEqual(whileNode.condition instanceof LocalVariableSyntaxNode, true);
-          assert.strictEqual(whileNode.statements instanceof SyntaxList, true);
-        }),
-      ];
-      Test.assertSyntaxNodes(syntaxTests);
-
-      let diagnosticTests = [
-        new DiagnosticTestArgs('while', 'missing open paren', [ErrorCode.ERR_OpenParenExpected], [5]),
-        new DiagnosticTestArgs('while (', 'missing expression', [ErrorCode.ERR_ExpressionExpectedEOF], [7]),
-        new DiagnosticTestArgs('while ($a', 'missing close paren', [ErrorCode.ERR_CloseParenExpected], [9]),
-        // NOTE: An open brace is NOT required, only an embedded statement.
-        new DiagnosticTestArgs('while ($a)', 'missing statement or colon', [ErrorCode.ERR_StatementOrColonExpected], [10]),
-        new DiagnosticTestArgs('while ($a):', 'missing statement or endwhile', [ErrorCode.ERR_Syntax], [11]),
-        new DiagnosticTestArgs('while ($a): endwhile', 'missing semicolon', [ErrorCode.ERR_SemicolonExpected], [20]),
-        new DiagnosticTestArgs('while ($a);', 'should warn if empty statement', [ErrorCode.WRN_PossibleMistakenEmptyStatement], [10]),
-      ];
-      Test.assertDiagnostics(diagnosticTests);
-    });
-
     describe('do-while-statement', function() {
       let syntaxTests = [
         new ParserTestArgs('do ; while ($a);', 'should parse a do-while statement', (statements) => {
@@ -307,6 +271,42 @@ describe('PhpParser', function() {
         new DiagnosticTestArgs('foreach ($a as list($k) =>', 'should not parse key-value pair with list key', [ErrorCode.ERR_CloseParenExpected], [23]),
         new DiagnosticTestArgs('foreach ($a as [$k] =>', 'should not parse key-value pair with list key (short syntax)', [ErrorCode.ERR_CloseParenExpected], [19]),
         new DiagnosticTestArgs('foreach ($a as $v);', 'should warn if empty statement', [ErrorCode.WRN_PossibleMistakenEmptyStatement], [18]),
+      ];
+      Test.assertDiagnostics(diagnosticTests);
+    });
+
+    describe('while-statement', function() {
+      let syntaxTests = [
+        new ParserTestArgs('while ($a) 1;', 'should parse a while statement', (statements) => {
+          let whileNode = <WhileSyntaxNode>statements[0];
+          assert.strictEqual(whileNode instanceof WhileSyntaxNode, true, 'is a WhileSyntaxNode');
+          assert.strictEqual(whileNode.condition instanceof LocalVariableSyntaxNode, true);
+          assert.strictEqual(whileNode.statement instanceof ExpressionStatementSyntaxNode, true);
+        }),
+        new ParserTestArgs('while ($a): endwhile;', 'should parse a while statement (alternate syntax)', (statements) => {
+          let whileNode = <WhileBlockSyntaxNode>statements[0];
+          assert.strictEqual(whileNode instanceof WhileBlockSyntaxNode, true, 'is a WhileBlockSyntaxNode');
+          assert.strictEqual(whileNode.condition instanceof LocalVariableSyntaxNode, true);
+          assert.strictEqual(whileNode.statements, null);
+        }),
+        new ParserTestArgs('while ($a): 1; endwhile;', 'should parse a while statement (alternate syntax; with child statement)', (statements) => {
+          let whileNode = <WhileBlockSyntaxNode>statements[0];
+          assert.strictEqual(whileNode instanceof WhileBlockSyntaxNode, true, 'is a WhileBlockSyntaxNode');
+          assert.strictEqual(whileNode.condition instanceof LocalVariableSyntaxNode, true);
+          assert.strictEqual(whileNode.statements instanceof SyntaxList, true);
+        }),
+      ];
+      Test.assertSyntaxNodes(syntaxTests);
+
+      let diagnosticTests = [
+        new DiagnosticTestArgs('while', 'missing open paren', [ErrorCode.ERR_OpenParenExpected], [5]),
+        new DiagnosticTestArgs('while (', 'missing expression', [ErrorCode.ERR_ExpressionExpectedEOF], [7]),
+        new DiagnosticTestArgs('while ($a', 'missing close paren', [ErrorCode.ERR_CloseParenExpected], [9]),
+        // NOTE: An open brace is NOT required, only an embedded statement.
+        new DiagnosticTestArgs('while ($a)', 'missing statement or colon', [ErrorCode.ERR_StatementOrColonExpected], [10]),
+        new DiagnosticTestArgs('while ($a):', 'missing statement or endwhile', [ErrorCode.ERR_Syntax], [11]),
+        new DiagnosticTestArgs('while ($a): endwhile', 'missing semicolon', [ErrorCode.ERR_SemicolonExpected], [20]),
+        new DiagnosticTestArgs('while ($a);', 'should warn if empty statement', [ErrorCode.WRN_PossibleMistakenEmptyStatement], [10]),
       ];
       Test.assertDiagnostics(diagnosticTests);
     });

--- a/test/src/parser/PhpParserTest_Statements_Iteration.ts
+++ b/test/src/parser/PhpParserTest_Statements_Iteration.ts
@@ -44,7 +44,7 @@ import { SyntaxList } from '../../../src/language/syntax/SyntaxList';
 
 function assertForEach(statements: ISyntaxNode[], hasKey: boolean, hasAmpersand: boolean): ForEachSyntaxNode {
   let forEachNode = <ForEachSyntaxNode>statements[0];
-  assert.strictEqual(forEachNode instanceof ForEachSyntaxNode, true, 'is a ForEachSyntaxNode');
+  assert.strictEqual(forEachNode instanceof ForEachSyntaxNode, true, 'ForEachSyntaxNode');
   assert.strictEqual(forEachNode.source instanceof LocalVariableSyntaxNode, true);
   if (hasKey) {
     assert.strictEqual(forEachNode.key instanceof LocalVariableSyntaxNode, true, 'LocalVariableSyntaxNode');
@@ -70,7 +70,7 @@ describe('PhpParser', function() {
       let syntaxTests = [
         new ParserTestArgs('do ; while ($a);', 'should parse a do-while statement', (statements) => {
           let doWhileNode = <DoWhileSyntaxNode>statements[0];
-          assert.strictEqual(doWhileNode instanceof DoWhileSyntaxNode, true, 'is a DoWhileSyntaxNode');
+          assert.strictEqual(doWhileNode instanceof DoWhileSyntaxNode, true, 'DoWhileSyntaxNode');
           assert.strictEqual(doWhileNode.statement instanceof ExpressionStatementSyntaxNode, true);
           assert.strictEqual(doWhileNode.condition instanceof LocalVariableSyntaxNode, true);
         }),
@@ -92,7 +92,7 @@ describe('PhpParser', function() {
       let syntaxTests = [
         new ParserTestArgs('for (;;) 1;', 'should parse a for statement', (statements) => {
           let forNode = <ForSyntaxNode>statements[0];
-          assert.strictEqual(forNode instanceof ForSyntaxNode, true, 'is a ForSyntaxNode');
+          assert.strictEqual(forNode instanceof ForSyntaxNode, true, 'ForSyntaxNode');
           assert.strictEqual(forNode.initializers, null);
           assert.strictEqual(forNode.conditions, null);
           assert.strictEqual(forNode.incrementors, null);
@@ -100,7 +100,7 @@ describe('PhpParser', function() {
         }),
         new ParserTestArgs('for ($i;;) 1;', 'should parse a for statement with single initializer expression', (statements) => {
           let forNode = <ForSyntaxNode>statements[0];
-          assert.strictEqual(forNode instanceof ForSyntaxNode, true, 'is a ForSyntaxNode');
+          assert.strictEqual(forNode instanceof ForSyntaxNode, true, 'ForSyntaxNode');
           let initializers = forNode.initializers ? forNode.initializers.childNodes() : [];
           assert.strictEqual(initializers.length, 1);
           assert.strictEqual(initializers[0] instanceof LocalVariableSyntaxNode, true);
@@ -110,7 +110,7 @@ describe('PhpParser', function() {
         }),
         new ParserTestArgs('for ($i,$j;;) 1;', 'should parse a for statement with multiple initializer expressions', (statements) => {
           let forNode = <ForSyntaxNode>statements[0];
-          assert.strictEqual(forNode instanceof ForSyntaxNode, true, 'is a ForSyntaxNode');
+          assert.strictEqual(forNode instanceof ForSyntaxNode, true, 'ForSyntaxNode');
           let initializers = forNode.initializers ? forNode.initializers.childNodes() : [];
           assert.strictEqual(initializers.length, 2);
           assert.strictEqual(initializers[0] instanceof LocalVariableSyntaxNode, true);
@@ -121,7 +121,7 @@ describe('PhpParser', function() {
         }),
         new ParserTestArgs('for (;$i;) 1;', 'should parse a for statement with single condition expression', (statements) => {
           let forNode = <ForSyntaxNode>statements[0];
-          assert.strictEqual(forNode instanceof ForSyntaxNode, true, 'is a ForSyntaxNode');
+          assert.strictEqual(forNode instanceof ForSyntaxNode, true, 'ForSyntaxNode');
           assert.strictEqual(forNode.initializers, null);
           let conditions = forNode.conditions ? forNode.conditions.childNodes() : [];
           assert.strictEqual(conditions.length, 1);
@@ -131,7 +131,7 @@ describe('PhpParser', function() {
         }),
         new ParserTestArgs('for (;$i,$j;) 1;', 'should parse a for statement with multiple condition expressions', (statements) => {
           let forNode = <ForSyntaxNode>statements[0];
-          assert.strictEqual(forNode instanceof ForSyntaxNode, true, 'is a ForSyntaxNode');
+          assert.strictEqual(forNode instanceof ForSyntaxNode, true, 'ForSyntaxNode');
           assert.strictEqual(forNode.initializers, null);
           let conditions = forNode.conditions ? forNode.conditions.childNodes() : [];
           assert.strictEqual(conditions.length, 2);
@@ -142,7 +142,7 @@ describe('PhpParser', function() {
         }),
         new ParserTestArgs('for (;;$i) 1;', 'should parse a for statement with single iteration expression', (statements) => {
           let forNode = <ForSyntaxNode>statements[0];
-          assert.strictEqual(forNode instanceof ForSyntaxNode, true, 'is a ForSyntaxNode');
+          assert.strictEqual(forNode instanceof ForSyntaxNode, true, 'ForSyntaxNode');
           assert.strictEqual(forNode.initializers, null);
           assert.strictEqual(forNode.conditions, null);
           let incrementors = forNode.incrementors ? forNode.incrementors.childNodes() : [];
@@ -152,7 +152,7 @@ describe('PhpParser', function() {
         }),
         new ParserTestArgs('for (;;$i,$j) 1;', 'should parse a for statement with multiple iteration expressions', (statements) => {
           let forNode = <ForSyntaxNode>statements[0];
-          assert.strictEqual(forNode instanceof ForSyntaxNode, true, 'is a ForSyntaxNode');
+          assert.strictEqual(forNode instanceof ForSyntaxNode, true, 'ForSyntaxNode');
           assert.strictEqual(forNode.initializers, null);
           assert.strictEqual(forNode.conditions, null);
           let incrementors = forNode.incrementors ? forNode.incrementors.childNodes() : [];
@@ -163,7 +163,7 @@ describe('PhpParser', function() {
         }),
         new ParserTestArgs('for (;;): endfor;', 'should parse a for statement (alternate syntax)', (statements) => {
           let forNode = <ForBlockSyntaxNode>statements[0];
-          assert.strictEqual(forNode instanceof ForBlockSyntaxNode, true, 'is a ForBlockSyntaxNode');
+          assert.strictEqual(forNode instanceof ForBlockSyntaxNode, true, 'ForBlockSyntaxNode');
           assert.strictEqual(forNode.initializers, null);
           assert.strictEqual(forNode.conditions, null);
           assert.strictEqual(forNode.incrementors, null);
@@ -171,7 +171,7 @@ describe('PhpParser', function() {
         }),
         new ParserTestArgs('for (;;): ; endfor;', 'should parse a for statement (alternate syntax; with child statement)', (statements) => {
           let forNode = <ForBlockSyntaxNode>statements[0];
-          assert.strictEqual(forNode instanceof ForBlockSyntaxNode, true, 'is a ForBlockSyntaxNode');
+          assert.strictEqual(forNode instanceof ForBlockSyntaxNode, true, 'ForBlockSyntaxNode');
           assert.strictEqual(forNode.initializers, null);
           assert.strictEqual(forNode.conditions, null);
           assert.strictEqual(forNode.incrementors, null);
@@ -236,7 +236,7 @@ describe('PhpParser', function() {
         }),
         new ParserTestArgs('foreach ($a as $v): endforeach;', 'should parse a foreach statement (alternate syntax)', (statements) => {
           let forEachNode = <ForEachBlockSyntaxNode>statements[0];
-          assert.strictEqual(forEachNode instanceof ForEachBlockSyntaxNode, true, 'is a ForEachBlockSyntaxNode');
+          assert.strictEqual(forEachNode instanceof ForEachBlockSyntaxNode, true, 'ForEachBlockSyntaxNode');
           assert.strictEqual(forEachNode.source instanceof LocalVariableSyntaxNode, true);
           assert.strictEqual(forEachNode.key, null);
           assert.strictEqual(forEachNode.ampersand, null);
@@ -245,7 +245,7 @@ describe('PhpParser', function() {
         }),
         new ParserTestArgs('foreach ($a as $v): ; endforeach;', 'should parse a foreach statement (alternate syntax; with child statement)', (statements) => {
           let forEachNode = <ForEachBlockSyntaxNode>statements[0];
-          assert.strictEqual(forEachNode instanceof ForEachBlockSyntaxNode, true, 'is a ForEachBlockSyntaxNode');
+          assert.strictEqual(forEachNode instanceof ForEachBlockSyntaxNode, true, 'ForEachBlockSyntaxNode');
           assert.strictEqual(forEachNode.source instanceof LocalVariableSyntaxNode, true);
           assert.strictEqual(forEachNode.key, null);
           assert.strictEqual(forEachNode.ampersand, null);
@@ -279,19 +279,19 @@ describe('PhpParser', function() {
       let syntaxTests = [
         new ParserTestArgs('while ($a) 1;', 'should parse a while statement', (statements) => {
           let whileNode = <WhileSyntaxNode>statements[0];
-          assert.strictEqual(whileNode instanceof WhileSyntaxNode, true, 'is a WhileSyntaxNode');
+          assert.strictEqual(whileNode instanceof WhileSyntaxNode, true, 'WhileSyntaxNode');
           assert.strictEqual(whileNode.condition instanceof LocalVariableSyntaxNode, true);
           assert.strictEqual(whileNode.statement instanceof ExpressionStatementSyntaxNode, true);
         }),
         new ParserTestArgs('while ($a): endwhile;', 'should parse a while statement (alternate syntax)', (statements) => {
           let whileNode = <WhileBlockSyntaxNode>statements[0];
-          assert.strictEqual(whileNode instanceof WhileBlockSyntaxNode, true, 'is a WhileBlockSyntaxNode');
+          assert.strictEqual(whileNode instanceof WhileBlockSyntaxNode, true, 'WhileBlockSyntaxNode');
           assert.strictEqual(whileNode.condition instanceof LocalVariableSyntaxNode, true);
           assert.strictEqual(whileNode.statements, null);
         }),
         new ParserTestArgs('while ($a): 1; endwhile;', 'should parse a while statement (alternate syntax; with child statement)', (statements) => {
           let whileNode = <WhileBlockSyntaxNode>statements[0];
-          assert.strictEqual(whileNode instanceof WhileBlockSyntaxNode, true, 'is a WhileBlockSyntaxNode');
+          assert.strictEqual(whileNode instanceof WhileBlockSyntaxNode, true, 'WhileBlockSyntaxNode');
           assert.strictEqual(whileNode.condition instanceof LocalVariableSyntaxNode, true);
           assert.strictEqual(whileNode.statements instanceof SyntaxList, true);
         }),

--- a/test/src/parser/PhpParserTest_Statements_Jump.ts
+++ b/test/src/parser/PhpParserTest_Statements_Jump.ts
@@ -36,6 +36,7 @@ import {
 } from '../../../src/language/syntax/SyntaxNode.Generated';
 
 import { ErrorCode } from '../../../src/diagnostics/ErrorCode.Generated';
+import { PhpVersion } from '../../../src/parser/PhpVersion';
 
 describe('PhpParser', function() {
 
@@ -155,13 +156,13 @@ describe('PhpParser', function() {
           assert.strictEqual(throwNode.expression instanceof LocalVariableSyntaxNode, true);
         }),
       ];
-      Test.assertSyntaxNodes(tests);
+      Test.assertSyntaxNodes(tests, PhpVersion.PHP7_0, PhpVersion.PHP7_4);
 
       let diagnosticTests = [
         new DiagnosticTestArgs('throw', 'missing expression', [ErrorCode.ERR_ExpressionExpectedEOF], [5]),
         new DiagnosticTestArgs('throw $e', 'missing semicolon', [ErrorCode.ERR_SemicolonExpected], [8]),
       ];
-      Test.assertDiagnostics(diagnosticTests);
+      Test.assertDiagnostics(diagnosticTests, PhpVersion.PHP7_0, PhpVersion.PHP7_4);
     });
 
   });

--- a/test/src/parser/PhpParserTest_TraitDeclaration.ts
+++ b/test/src/parser/PhpParserTest_TraitDeclaration.ts
@@ -153,6 +153,237 @@ describe('PhpParser', function() {
       Test.assertDiagnostics(diagnosticTests);
     });
 
+    // Everything except for the parameter list and statement block needs full
+    // testing since it uses a different implementation than `function-declaration`.
+    describe('method-declaration', function() {
+      let syntaxTests = [
+        new ParserTestArgs('trait A { function b() {} }', 'should parse a method declaration', (statements, text) => {
+          let method = assertMethodDeclaration(statements);
+          assert.strictEqual(method.modifiers, null);
+          assert.strictEqual(method.ampersand, null);
+          Test.assertSyntaxToken(method.identifierOrKeyword, text, TokenKind.Identifier, 'b');
+          assert.strictEqual(method.returnType, null);
+        }),
+        new ParserTestArgs('trait A { function list() {} }', 'should parse a method declaration with semi-reserved keyword', (statements, text) => {
+          let method = assertMethodDeclaration(statements);
+          assert.strictEqual(method.modifiers, null);
+          assert.strictEqual(method.ampersand, null);
+          Test.assertSyntaxToken(method.identifierOrKeyword, text, TokenKind.List, 'list');
+          assert.strictEqual(method.returnType, null);
+        }),
+        new ParserTestArgs('trait A { function &b() {} }', 'should parse a method declaration with ampersand', (statements, text) => {
+          let method = assertMethodDeclaration(statements);
+          assert.strictEqual(method.modifiers, null);
+          assert.notStrictEqual(method.ampersand, null);
+          Test.assertSyntaxToken(method.identifierOrKeyword, text, TokenKind.Identifier, 'b');
+          assert.strictEqual(method.returnType, null);
+        }),
+
+        // Modifiers.
+        new ParserTestArgs('trait A { abstract function b(); }', 'should parse an abstract method declaration', (statements, text) => {
+          let method = assertMethodDeclaration(statements);
+          let modifiers = method.modifiers ? method.modifiers.childTokens() : [];
+          assert.strictEqual(modifiers.length, 1);
+          Test.assertSyntaxToken(modifiers[0], text, TokenKind.Abstract, 'abstract');
+          assert.strictEqual(method.ampersand, null);
+          Test.assertSyntaxToken(method.identifierOrKeyword, text, TokenKind.Identifier, 'b');
+          assert.strictEqual(method.returnType, null);
+        }),
+        new ParserTestArgs('trait A { final function b() {} }', 'should parse a final method declaration', (statements, text) => {
+          let method = assertMethodDeclaration(statements);
+          let modifiers = method.modifiers ? method.modifiers.childTokens() : [];
+          assert.strictEqual(modifiers.length, 1);
+          Test.assertSyntaxToken(modifiers[0], text, TokenKind.Final, 'final');
+          assert.strictEqual(method.ampersand, null);
+          Test.assertSyntaxToken(method.identifierOrKeyword, text, TokenKind.Identifier, 'b');
+          assert.strictEqual(method.returnType, null);
+        }),
+        new ParserTestArgs('trait A { private function b() {} }', 'should parse a private method declaration', (statements, text) => {
+          let method = assertMethodDeclaration(statements);
+          let modifiers = method.modifiers ? method.modifiers.childTokens() : [];
+          assert.strictEqual(modifiers.length, 1);
+          Test.assertSyntaxToken(modifiers[0], text, TokenKind.Private, 'private');
+          assert.strictEqual(method.ampersand, null);
+          Test.assertSyntaxToken(method.identifierOrKeyword, text, TokenKind.Identifier, 'b');
+          assert.strictEqual(method.returnType, null);
+        }),
+        new ParserTestArgs('trait A { protected function b() {} }', 'should parse a protected method declaration', (statements, text) => {
+          let method = assertMethodDeclaration(statements);
+          let modifiers = method.modifiers ? method.modifiers.childTokens() : [];
+          assert.strictEqual(modifiers.length, 1);
+          Test.assertSyntaxToken(modifiers[0], text, TokenKind.Protected, 'protected');
+          assert.strictEqual(method.ampersand, null);
+          Test.assertSyntaxToken(method.identifierOrKeyword, text, TokenKind.Identifier, 'b');
+          assert.strictEqual(method.returnType, null);
+        }),
+        new ParserTestArgs('trait A { public function b() {} }', 'should parse a public method declaration', (statements, text) => {
+          let method = assertMethodDeclaration(statements);
+          let modifiers = method.modifiers ? method.modifiers.childTokens() : [];
+          assert.strictEqual(modifiers.length, 1);
+          Test.assertSyntaxToken(modifiers[0], text, TokenKind.Public, 'public');
+          assert.strictEqual(method.ampersand, null);
+          Test.assertSyntaxToken(method.identifierOrKeyword, text, TokenKind.Identifier, 'b');
+          assert.strictEqual(method.returnType, null);
+        }),
+        new ParserTestArgs('trait A { static function b() {} }', 'should parse a static method declaration', (statements, text) => {
+          let method = assertMethodDeclaration(statements);
+          let modifiers = method.modifiers ? method.modifiers.childTokens() : [];
+          assert.strictEqual(modifiers.length, 1);
+          Test.assertSyntaxToken(modifiers[0], text, TokenKind.Static, 'static');
+          assert.strictEqual(method.ampersand, null);
+          Test.assertSyntaxToken(method.identifierOrKeyword, text, TokenKind.Identifier, 'b');
+          assert.strictEqual(method.returnType, null);
+        }),
+
+        // Modifiers (mixed).
+        new ParserTestArgs('trait A { abstract protected function b(); }', 'should parse an abstract and protected method declaration', (statements, text) => {
+          let method = assertMethodDeclaration(statements);
+          let modifiers = method.modifiers ? method.modifiers.childTokens() : [];
+          assert.strictEqual(modifiers.length, 2);
+          Test.assertSyntaxToken(modifiers[0], text, TokenKind.Abstract, 'abstract');
+          Test.assertSyntaxToken(modifiers[1], text, TokenKind.Protected, 'protected');
+          assert.strictEqual(method.ampersand, null);
+          Test.assertSyntaxToken(method.identifierOrKeyword, text, TokenKind.Identifier, 'b');
+          assert.strictEqual(method.returnType, null);
+        }),
+        new ParserTestArgs('trait A { abstract public function b(); }', 'should parse an abstract and public method declaration', (statements, text) => {
+          let method = assertMethodDeclaration(statements);
+          let modifiers = method.modifiers ? method.modifiers.childTokens() : [];
+          assert.strictEqual(modifiers.length, 2);
+          Test.assertSyntaxToken(modifiers[0], text, TokenKind.Abstract, 'abstract');
+          Test.assertSyntaxToken(modifiers[1], text, TokenKind.Public, 'public');
+          assert.strictEqual(method.ampersand, null);
+          Test.assertSyntaxToken(method.identifierOrKeyword, text, TokenKind.Identifier, 'b');
+          assert.strictEqual(method.returnType, null);
+        }),
+        new ParserTestArgs('trait A { abstract static function b(); }', 'should parse an abstract and static method declaration', (statements, text) => {
+          let method = assertMethodDeclaration(statements);
+          let modifiers = method.modifiers ? method.modifiers.childTokens() : [];
+          assert.strictEqual(modifiers.length, 2);
+          Test.assertSyntaxToken(modifiers[0], text, TokenKind.Abstract, 'abstract');
+          Test.assertSyntaxToken(modifiers[1], text, TokenKind.Static, 'static');
+          assert.strictEqual(method.ampersand, null);
+          Test.assertSyntaxToken(method.identifierOrKeyword, text, TokenKind.Identifier, 'b');
+          assert.strictEqual(method.returnType, null);
+        }),
+        new ParserTestArgs('trait A { static final function b() {} }', 'should parse a static and final method declaration', (statements, text) => {
+          let method = assertMethodDeclaration(statements);
+          let modifiers = method.modifiers ? method.modifiers.childTokens() : [];
+          assert.strictEqual(modifiers.length, 2);
+          Test.assertSyntaxToken(modifiers[0], text, TokenKind.Static, 'static');
+          Test.assertSyntaxToken(modifiers[1], text, TokenKind.Final, 'final');
+          assert.strictEqual(method.ampersand, null);
+          Test.assertSyntaxToken(method.identifierOrKeyword, text, TokenKind.Identifier, 'b');
+          assert.strictEqual(method.returnType, null);
+        }),
+        new ParserTestArgs('trait A { static private function b() {} }', 'should parse a static and private method declaration', (statements, text) => {
+          let method = assertMethodDeclaration(statements);
+          let modifiers = method.modifiers ? method.modifiers.childTokens() : [];
+          assert.strictEqual(modifiers.length, 2);
+          Test.assertSyntaxToken(modifiers[0], text, TokenKind.Static, 'static');
+          Test.assertSyntaxToken(modifiers[1], text, TokenKind.Private, 'private');
+          assert.strictEqual(method.ampersand, null);
+          Test.assertSyntaxToken(method.identifierOrKeyword, text, TokenKind.Identifier, 'b');
+          assert.strictEqual(method.returnType, null);
+        }),
+        new ParserTestArgs('trait A { static protected function b() {} }', 'should parse a static and protected method declaration', (statements, text) => {
+          let method = assertMethodDeclaration(statements);
+          let modifiers = method.modifiers ? method.modifiers.childTokens() : [];
+          assert.strictEqual(modifiers.length, 2);
+          Test.assertSyntaxToken(modifiers[0], text, TokenKind.Static, 'static');
+          Test.assertSyntaxToken(modifiers[1], text, TokenKind.Protected, 'protected');
+          assert.strictEqual(method.ampersand, null);
+          Test.assertSyntaxToken(method.identifierOrKeyword, text, TokenKind.Identifier, 'b');
+          assert.strictEqual(method.returnType, null);
+        }),
+        new ParserTestArgs('trait A { static public function b() {} }', 'should parse a static and public method declaration', (statements, text) => {
+          let method = assertMethodDeclaration(statements);
+          let modifiers = method.modifiers ? method.modifiers.childTokens() : [];
+          assert.strictEqual(modifiers.length, 2);
+          Test.assertSyntaxToken(modifiers[0], text, TokenKind.Static, 'static');
+          Test.assertSyntaxToken(modifiers[1], text, TokenKind.Public, 'public');
+          assert.strictEqual(method.ampersand, null);
+          Test.assertSyntaxToken(method.identifierOrKeyword, text, TokenKind.Identifier, 'b');
+          assert.strictEqual(method.returnType, null);
+        }),
+
+        // Return types.
+        new ParserTestArgs('trait A { function b(): C {} }', 'should parse a method declaration with return type', (statements, text) => {
+          let method = assertMethodDeclaration(statements);
+          assert.strictEqual(method.modifiers, null);
+          assert.strictEqual(method.ampersand, null);
+          Test.assertSyntaxToken(method.identifierOrKeyword, text, TokenKind.Identifier, 'b');
+          assert.strictEqual(method.returnType instanceof TypeSyntaxNode, true);
+        }),
+        new ParserTestArgs('trait A { function b(): \\C {} }', 'should parse a method declaration with fully qualified return type', (statements, text) => {
+          let method = assertMethodDeclaration(statements);
+          assert.strictEqual(method.modifiers, null);
+          assert.strictEqual(method.ampersand, null);
+          Test.assertSyntaxToken(method.identifierOrKeyword, text, TokenKind.Identifier, 'b');
+          assert.strictEqual(method.returnType instanceof TypeSyntaxNode, true);
+        }),
+        new ParserTestArgs('trait A { function b(): namespace\\C {} }', 'should parse a method declaration with relative return type', (statements, text) => {
+          let method = assertMethodDeclaration(statements);
+          assert.strictEqual(method.modifiers, null);
+          assert.strictEqual(method.ampersand, null);
+          Test.assertSyntaxToken(method.identifierOrKeyword, text, TokenKind.Identifier, 'b');
+          assert.strictEqual(method.returnType instanceof TypeSyntaxNode, true);
+        }),
+        new ParserTestArgs('trait A { function b(): array {} }', 'should parse a method declaration with predefined return type (array)', (statements, text) => {
+          let method = assertMethodDeclaration(statements);
+          assert.strictEqual(method.modifiers, null);
+          assert.strictEqual(method.ampersand, null);
+          Test.assertSyntaxToken(method.identifierOrKeyword, text, TokenKind.Identifier, 'b');
+          assert.strictEqual(method.returnType instanceof PredefinedTypeSyntaxNode, true);
+        }),
+        new ParserTestArgs('trait A { function b(): callable {} }', 'should parse a method declaration with predefined return type (callable)', (statements, text) => {
+          let method = assertMethodDeclaration(statements);
+          assert.strictEqual(method.modifiers, null);
+          assert.strictEqual(method.ampersand, null);
+          Test.assertSyntaxToken(method.identifierOrKeyword, text, TokenKind.Identifier, 'b');
+          assert.strictEqual(method.returnType instanceof PredefinedTypeSyntaxNode, true);
+        }),
+      ];
+      Test.assertSyntaxNodes(syntaxTests);
+
+      let syntaxTests7_1 = [
+        new ParserTestArgs('trait A { function b(): ? C {} }', 'should parse a method declaration with nullable return type', (statements, text) => {
+          let method = assertMethodDeclaration(statements);
+          assert.strictEqual(method.modifiers, null);
+          assert.strictEqual(method.ampersand, null);
+          Test.assertSyntaxToken(method.identifierOrKeyword, text, TokenKind.Identifier, 'b');
+          let returnType = <NamedTypeSyntaxNode>method.returnType;
+          assert.strictEqual(returnType instanceof NamedTypeSyntaxNode, true, 'NamedTypeSyntaxNode');
+          assert.notStrictEqual(returnType.question, null);
+          assert.strictEqual(returnType.typeName instanceof PartiallyQualifiedNameSyntaxNode, true);
+        }),
+      ];
+      Test.assertSyntaxNodes(syntaxTests7_1, PhpVersion.PHP7_1);
+
+      let diagnosticTests = [
+        new DiagnosticTestArgs('trait A { function }', 'missing method name or ampersand', [ErrorCode.ERR_MethodNameOrAmpersandExpected], [18]),
+        new DiagnosticTestArgs('trait A { function &', 'missing method name (after ampersand)', [ErrorCode.ERR_MethodNameExpected], [20]),
+        new DiagnosticTestArgs('trait A { function b }', 'missing open paren', [ErrorCode.ERR_OpenParenExpected], [20]),
+        new DiagnosticTestArgs('trait A { function b( }', 'missing ampersand, ellipsis, question, type, variable, or close paren', [ErrorCode.ERR_ParameterOrCloseParenExpected], [21]),
+        new DiagnosticTestArgs('trait A { function b() }', 'missing open brace or colon', [ErrorCode.ERR_OpenBraceOrColonExpected], [22]),
+
+        new DiagnosticTestArgs('trait A { function b():', 'missing return type', [ErrorCode.ERR_TypeExpected], [23]),
+        new DiagnosticTestArgs('trait A { function b(): C\\ }', 'missing identifier in return type', [ErrorCode.ERR_IdentifierExpected], [26]),
+        new DiagnosticTestArgs('trait A { function b(): \\ }', 'missing identifier in return type (fully qualified name)', [ErrorCode.ERR_IdentifierExpected], [25]),
+        new DiagnosticTestArgs('trait A { function b(); }', 'should not expect a semicolon after a non-abstract method declaration', [ErrorCode.ERR_OpenBraceOrColonExpected], [22]),
+
+        new DiagnosticTestArgs('trait A { abstract function b() }', 'missing colon or semicolon', [ErrorCode.ERR_ColonOrSemicolonExpected], [31]),
+        new DiagnosticTestArgs('trait A { abstract function b() {} }', 'should not expect method body on abstract method', [ErrorCode.ERR_AbstractMethodHasBody], [32]),
+        new DiagnosticTestArgs('trait A { abstract final function b(); }', 'should not expect abstract and final modifiers', [ErrorCode.ERR_AbstractMemberIsFinal], [19]),
+        new DiagnosticTestArgs('trait A { abstract private function b(); }', 'should not expect abstract and private modifiers', [ErrorCode.ERR_AbstractMemberIsPrivate], [19]),
+
+        // @todo These should be recovery tests.
+        new DiagnosticTestArgs('trait A { function b() { }', 'missing close brace', [ErrorCode.ERR_CloseBraceExpected], [26]),
+        new DiagnosticTestArgs('trait A { function b() { public $c; }', 'missing close brace with trailing class member', [ErrorCode.ERR_CloseBraceExpected], [24]),
+      ];
+      Test.assertDiagnostics(diagnosticTests);
+    });
+
     describe('property-declaration', function() {
       let syntaxTests = [
         new ParserTestArgs('trait A { public $b; }', 'should parse a property declaration', (statements, text) => {
@@ -386,237 +617,6 @@ describe('PhpParser', function() {
         new DiagnosticTestArgs('trait A { public B $c; }', 'should not parse a typed property', [ErrorCode.ERR_FeatureTypedProperties], [17]),
       ];
       Test.assertDiagnostics(featureTypedProperties, PhpVersion.PHP7_0, PhpVersion.PHP7_3);
-    });
-
-    // Everything except for the parameter list and statement block needs full
-    // testing since it uses a different implementation than `function-declaration`.
-    describe('method-declaration', function() {
-      let syntaxTests = [
-        new ParserTestArgs('trait A { function b() {} }', 'should parse a method declaration', (statements, text) => {
-          let method = assertMethodDeclaration(statements);
-          assert.strictEqual(method.modifiers, null);
-          assert.strictEqual(method.ampersand, null);
-          Test.assertSyntaxToken(method.identifierOrKeyword, text, TokenKind.Identifier, 'b');
-          assert.strictEqual(method.returnType, null);
-        }),
-        new ParserTestArgs('trait A { function list() {} }', 'should parse a method declaration with semi-reserved keyword', (statements, text) => {
-          let method = assertMethodDeclaration(statements);
-          assert.strictEqual(method.modifiers, null);
-          assert.strictEqual(method.ampersand, null);
-          Test.assertSyntaxToken(method.identifierOrKeyword, text, TokenKind.List, 'list');
-          assert.strictEqual(method.returnType, null);
-        }),
-        new ParserTestArgs('trait A { function &b() {} }', 'should parse a method declaration with ampersand', (statements, text) => {
-          let method = assertMethodDeclaration(statements);
-          assert.strictEqual(method.modifiers, null);
-          assert.notStrictEqual(method.ampersand, null);
-          Test.assertSyntaxToken(method.identifierOrKeyword, text, TokenKind.Identifier, 'b');
-          assert.strictEqual(method.returnType, null);
-        }),
-
-        // Modifiers.
-        new ParserTestArgs('trait A { abstract function b(); }', 'should parse an abstract method declaration', (statements, text) => {
-          let method = assertMethodDeclaration(statements);
-          let modifiers = method.modifiers ? method.modifiers.childTokens() : [];
-          assert.strictEqual(modifiers.length, 1);
-          Test.assertSyntaxToken(modifiers[0], text, TokenKind.Abstract, 'abstract');
-          assert.strictEqual(method.ampersand, null);
-          Test.assertSyntaxToken(method.identifierOrKeyword, text, TokenKind.Identifier, 'b');
-          assert.strictEqual(method.returnType, null);
-        }),
-        new ParserTestArgs('trait A { final function b() {} }', 'should parse a final method declaration', (statements, text) => {
-          let method = assertMethodDeclaration(statements);
-          let modifiers = method.modifiers ? method.modifiers.childTokens() : [];
-          assert.strictEqual(modifiers.length, 1);
-          Test.assertSyntaxToken(modifiers[0], text, TokenKind.Final, 'final');
-          assert.strictEqual(method.ampersand, null);
-          Test.assertSyntaxToken(method.identifierOrKeyword, text, TokenKind.Identifier, 'b');
-          assert.strictEqual(method.returnType, null);
-        }),
-        new ParserTestArgs('trait A { private function b() {} }', 'should parse a private method declaration', (statements, text) => {
-          let method = assertMethodDeclaration(statements);
-          let modifiers = method.modifiers ? method.modifiers.childTokens() : [];
-          assert.strictEqual(modifiers.length, 1);
-          Test.assertSyntaxToken(modifiers[0], text, TokenKind.Private, 'private');
-          assert.strictEqual(method.ampersand, null);
-          Test.assertSyntaxToken(method.identifierOrKeyword, text, TokenKind.Identifier, 'b');
-          assert.strictEqual(method.returnType, null);
-        }),
-        new ParserTestArgs('trait A { protected function b() {} }', 'should parse a protected method declaration', (statements, text) => {
-          let method = assertMethodDeclaration(statements);
-          let modifiers = method.modifiers ? method.modifiers.childTokens() : [];
-          assert.strictEqual(modifiers.length, 1);
-          Test.assertSyntaxToken(modifiers[0], text, TokenKind.Protected, 'protected');
-          assert.strictEqual(method.ampersand, null);
-          Test.assertSyntaxToken(method.identifierOrKeyword, text, TokenKind.Identifier, 'b');
-          assert.strictEqual(method.returnType, null);
-        }),
-        new ParserTestArgs('trait A { public function b() {} }', 'should parse a public method declaration', (statements, text) => {
-          let method = assertMethodDeclaration(statements);
-          let modifiers = method.modifiers ? method.modifiers.childTokens() : [];
-          assert.strictEqual(modifiers.length, 1);
-          Test.assertSyntaxToken(modifiers[0], text, TokenKind.Public, 'public');
-          assert.strictEqual(method.ampersand, null);
-          Test.assertSyntaxToken(method.identifierOrKeyword, text, TokenKind.Identifier, 'b');
-          assert.strictEqual(method.returnType, null);
-        }),
-        new ParserTestArgs('trait A { static function b() {} }', 'should parse a static method declaration', (statements, text) => {
-          let method = assertMethodDeclaration(statements);
-          let modifiers = method.modifiers ? method.modifiers.childTokens() : [];
-          assert.strictEqual(modifiers.length, 1);
-          Test.assertSyntaxToken(modifiers[0], text, TokenKind.Static, 'static');
-          assert.strictEqual(method.ampersand, null);
-          Test.assertSyntaxToken(method.identifierOrKeyword, text, TokenKind.Identifier, 'b');
-          assert.strictEqual(method.returnType, null);
-        }),
-
-        // Modifiers (mixed).
-        new ParserTestArgs('trait A { abstract protected function b(); }', 'should parse an abstract and protected method declaration', (statements, text) => {
-          let method = assertMethodDeclaration(statements);
-          let modifiers = method.modifiers ? method.modifiers.childTokens() : [];
-          assert.strictEqual(modifiers.length, 2);
-          Test.assertSyntaxToken(modifiers[0], text, TokenKind.Abstract, 'abstract');
-          Test.assertSyntaxToken(modifiers[1], text, TokenKind.Protected, 'protected');
-          assert.strictEqual(method.ampersand, null);
-          Test.assertSyntaxToken(method.identifierOrKeyword, text, TokenKind.Identifier, 'b');
-          assert.strictEqual(method.returnType, null);
-        }),
-        new ParserTestArgs('trait A { abstract public function b(); }', 'should parse an abstract and public method declaration', (statements, text) => {
-          let method = assertMethodDeclaration(statements);
-          let modifiers = method.modifiers ? method.modifiers.childTokens() : [];
-          assert.strictEqual(modifiers.length, 2);
-          Test.assertSyntaxToken(modifiers[0], text, TokenKind.Abstract, 'abstract');
-          Test.assertSyntaxToken(modifiers[1], text, TokenKind.Public, 'public');
-          assert.strictEqual(method.ampersand, null);
-          Test.assertSyntaxToken(method.identifierOrKeyword, text, TokenKind.Identifier, 'b');
-          assert.strictEqual(method.returnType, null);
-        }),
-        new ParserTestArgs('trait A { abstract static function b(); }', 'should parse an abstract and static method declaration', (statements, text) => {
-          let method = assertMethodDeclaration(statements);
-          let modifiers = method.modifiers ? method.modifiers.childTokens() : [];
-          assert.strictEqual(modifiers.length, 2);
-          Test.assertSyntaxToken(modifiers[0], text, TokenKind.Abstract, 'abstract');
-          Test.assertSyntaxToken(modifiers[1], text, TokenKind.Static, 'static');
-          assert.strictEqual(method.ampersand, null);
-          Test.assertSyntaxToken(method.identifierOrKeyword, text, TokenKind.Identifier, 'b');
-          assert.strictEqual(method.returnType, null);
-        }),
-        new ParserTestArgs('trait A { static final function b() {} }', 'should parse a static and final method declaration', (statements, text) => {
-          let method = assertMethodDeclaration(statements);
-          let modifiers = method.modifiers ? method.modifiers.childTokens() : [];
-          assert.strictEqual(modifiers.length, 2);
-          Test.assertSyntaxToken(modifiers[0], text, TokenKind.Static, 'static');
-          Test.assertSyntaxToken(modifiers[1], text, TokenKind.Final, 'final');
-          assert.strictEqual(method.ampersand, null);
-          Test.assertSyntaxToken(method.identifierOrKeyword, text, TokenKind.Identifier, 'b');
-          assert.strictEqual(method.returnType, null);
-        }),
-        new ParserTestArgs('trait A { static private function b() {} }', 'should parse a static and private method declaration', (statements, text) => {
-          let method = assertMethodDeclaration(statements);
-          let modifiers = method.modifiers ? method.modifiers.childTokens() : [];
-          assert.strictEqual(modifiers.length, 2);
-          Test.assertSyntaxToken(modifiers[0], text, TokenKind.Static, 'static');
-          Test.assertSyntaxToken(modifiers[1], text, TokenKind.Private, 'private');
-          assert.strictEqual(method.ampersand, null);
-          Test.assertSyntaxToken(method.identifierOrKeyword, text, TokenKind.Identifier, 'b');
-          assert.strictEqual(method.returnType, null);
-        }),
-        new ParserTestArgs('trait A { static protected function b() {} }', 'should parse a static and protected method declaration', (statements, text) => {
-          let method = assertMethodDeclaration(statements);
-          let modifiers = method.modifiers ? method.modifiers.childTokens() : [];
-          assert.strictEqual(modifiers.length, 2);
-          Test.assertSyntaxToken(modifiers[0], text, TokenKind.Static, 'static');
-          Test.assertSyntaxToken(modifiers[1], text, TokenKind.Protected, 'protected');
-          assert.strictEqual(method.ampersand, null);
-          Test.assertSyntaxToken(method.identifierOrKeyword, text, TokenKind.Identifier, 'b');
-          assert.strictEqual(method.returnType, null);
-        }),
-        new ParserTestArgs('trait A { static public function b() {} }', 'should parse a static and public method declaration', (statements, text) => {
-          let method = assertMethodDeclaration(statements);
-          let modifiers = method.modifiers ? method.modifiers.childTokens() : [];
-          assert.strictEqual(modifiers.length, 2);
-          Test.assertSyntaxToken(modifiers[0], text, TokenKind.Static, 'static');
-          Test.assertSyntaxToken(modifiers[1], text, TokenKind.Public, 'public');
-          assert.strictEqual(method.ampersand, null);
-          Test.assertSyntaxToken(method.identifierOrKeyword, text, TokenKind.Identifier, 'b');
-          assert.strictEqual(method.returnType, null);
-        }),
-
-        // Return types.
-        new ParserTestArgs('trait A { function b(): C {} }', 'should parse a method declaration with return type', (statements, text) => {
-          let method = assertMethodDeclaration(statements);
-          assert.strictEqual(method.modifiers, null);
-          assert.strictEqual(method.ampersand, null);
-          Test.assertSyntaxToken(method.identifierOrKeyword, text, TokenKind.Identifier, 'b');
-          assert.strictEqual(method.returnType instanceof TypeSyntaxNode, true);
-        }),
-        new ParserTestArgs('trait A { function b(): \\C {} }', 'should parse a method declaration with fully qualified return type', (statements, text) => {
-          let method = assertMethodDeclaration(statements);
-          assert.strictEqual(method.modifiers, null);
-          assert.strictEqual(method.ampersand, null);
-          Test.assertSyntaxToken(method.identifierOrKeyword, text, TokenKind.Identifier, 'b');
-          assert.strictEqual(method.returnType instanceof TypeSyntaxNode, true);
-        }),
-        new ParserTestArgs('trait A { function b(): namespace\\C {} }', 'should parse a method declaration with relative return type', (statements, text) => {
-          let method = assertMethodDeclaration(statements);
-          assert.strictEqual(method.modifiers, null);
-          assert.strictEqual(method.ampersand, null);
-          Test.assertSyntaxToken(method.identifierOrKeyword, text, TokenKind.Identifier, 'b');
-          assert.strictEqual(method.returnType instanceof TypeSyntaxNode, true);
-        }),
-        new ParserTestArgs('trait A { function b(): array {} }', 'should parse a method declaration with predefined return type (array)', (statements, text) => {
-          let method = assertMethodDeclaration(statements);
-          assert.strictEqual(method.modifiers, null);
-          assert.strictEqual(method.ampersand, null);
-          Test.assertSyntaxToken(method.identifierOrKeyword, text, TokenKind.Identifier, 'b');
-          assert.strictEqual(method.returnType instanceof PredefinedTypeSyntaxNode, true);
-        }),
-        new ParserTestArgs('trait A { function b(): callable {} }', 'should parse a method declaration with predefined return type (callable)', (statements, text) => {
-          let method = assertMethodDeclaration(statements);
-          assert.strictEqual(method.modifiers, null);
-          assert.strictEqual(method.ampersand, null);
-          Test.assertSyntaxToken(method.identifierOrKeyword, text, TokenKind.Identifier, 'b');
-          assert.strictEqual(method.returnType instanceof PredefinedTypeSyntaxNode, true);
-        }),
-      ];
-      Test.assertSyntaxNodes(syntaxTests);
-
-      let syntaxTests7_1 = [
-        new ParserTestArgs('trait A { function b(): ? C {} }', 'should parse a method declaration with nullable return type', (statements, text) => {
-          let method = assertMethodDeclaration(statements);
-          assert.strictEqual(method.modifiers, null);
-          assert.strictEqual(method.ampersand, null);
-          Test.assertSyntaxToken(method.identifierOrKeyword, text, TokenKind.Identifier, 'b');
-          let returnType = <NamedTypeSyntaxNode>method.returnType;
-          assert.strictEqual(returnType instanceof NamedTypeSyntaxNode, true, 'NamedTypeSyntaxNode');
-          assert.notStrictEqual(returnType.question, null);
-          assert.strictEqual(returnType.typeName instanceof PartiallyQualifiedNameSyntaxNode, true);
-        }),
-      ];
-      Test.assertSyntaxNodes(syntaxTests7_1, PhpVersion.PHP7_1);
-
-      let diagnosticTests = [
-        new DiagnosticTestArgs('trait A { function }', 'missing method name or ampersand', [ErrorCode.ERR_MethodNameOrAmpersandExpected], [18]),
-        new DiagnosticTestArgs('trait A { function &', 'missing method name (after ampersand)', [ErrorCode.ERR_MethodNameExpected], [20]),
-        new DiagnosticTestArgs('trait A { function b }', 'missing open paren', [ErrorCode.ERR_OpenParenExpected], [20]),
-        new DiagnosticTestArgs('trait A { function b( }', 'missing ampersand, ellipsis, question, type, variable, or close paren', [ErrorCode.ERR_ParameterOrCloseParenExpected], [21]),
-        new DiagnosticTestArgs('trait A { function b() }', 'missing open brace or colon', [ErrorCode.ERR_OpenBraceOrColonExpected], [22]),
-
-        new DiagnosticTestArgs('trait A { function b():', 'missing return type', [ErrorCode.ERR_TypeExpected], [23]),
-        new DiagnosticTestArgs('trait A { function b(): C\\ }', 'missing identifier in return type', [ErrorCode.ERR_IdentifierExpected], [26]),
-        new DiagnosticTestArgs('trait A { function b(): \\ }', 'missing identifier in return type (fully qualified name)', [ErrorCode.ERR_IdentifierExpected], [25]),
-        new DiagnosticTestArgs('trait A { function b(); }', 'should not expect a semicolon after a non-abstract method declaration', [ErrorCode.ERR_OpenBraceOrColonExpected], [22]),
-
-        new DiagnosticTestArgs('trait A { abstract function b() }', 'missing colon or semicolon', [ErrorCode.ERR_ColonOrSemicolonExpected], [31]),
-        new DiagnosticTestArgs('trait A { abstract function b() {} }', 'should not expect method body on abstract method', [ErrorCode.ERR_AbstractMethodHasBody], [32]),
-        new DiagnosticTestArgs('trait A { abstract final function b(); }', 'should not expect abstract and final modifiers', [ErrorCode.ERR_AbstractMemberIsFinal], [19]),
-        new DiagnosticTestArgs('trait A { abstract private function b(); }', 'should not expect abstract and private modifiers', [ErrorCode.ERR_AbstractMemberIsPrivate], [19]),
-
-        // @todo These should be recovery tests.
-        new DiagnosticTestArgs('trait A { function b() { }', 'missing close brace', [ErrorCode.ERR_CloseBraceExpected], [26]),
-        new DiagnosticTestArgs('trait A { function b() { public $c; }', 'missing close brace with trailing class member', [ErrorCode.ERR_CloseBraceExpected], [24]),
-      ];
-      Test.assertDiagnostics(diagnosticTests);
     });
 
     describe('trait-use-clause', function() {

--- a/test/src/parser/PhpParserTest_TraitDeclaration.ts
+++ b/test/src/parser/PhpParserTest_TraitDeclaration.ts
@@ -31,6 +31,7 @@ import {
   MethodReferenceSyntaxNode,
   NamedTraitAliasSyntaxNode,
   NamedTypeSyntaxNode,
+  ParameterSyntaxNode,
   PartiallyQualifiedNameSyntaxNode,
   PredefinedTypeSyntaxNode,
   PropertyDeclarationSyntaxNode,
@@ -58,6 +59,43 @@ function assertMethodDeclaration(statements: ISyntaxNode[]): MethodDeclarationSy
   let method = <MethodDeclarationSyntaxNode>members[0];
   assert.strictEqual(method instanceof MethodDeclarationSyntaxNode, true);
   return method;
+}
+
+function assertMethodDeclarationWithParameters(statements: ISyntaxNode[]): ISyntaxNode[] {
+  let method = assertMethodDeclaration(statements);
+  assert.strictEqual(method.modifiers, null);
+  assert.strictEqual(method.ampersand, null);
+  assert.strictEqual(method.returnType, null);
+  let parameters = method.parameters ? method.parameters.childNodes() : [];
+  return parameters;
+}
+
+function assertMethodParameter(node: ISyntaxNode, hasModifiers: boolean, hasType: boolean, hasAmpersand: boolean, hasEllipsis: boolean, hasDefaultValue: boolean): ParameterSyntaxNode {
+  let parameter = <ParameterSyntaxNode>node;
+  assert.strictEqual(parameter instanceof ParameterSyntaxNode, true, 'ParameterSyntaxNode');
+  if (!hasModifiers) {
+    assert.strictEqual(parameter.modifiers, null);
+  }
+  if (!hasType) {
+    assert.strictEqual(parameter.type, null);
+  }
+  if (hasAmpersand) {
+    assert.notStrictEqual(parameter.ampersand, null);
+  }
+  else {
+    assert.strictEqual(parameter.ampersand, null);
+  }
+  if (hasEllipsis) {
+    assert.notStrictEqual(parameter.ellipsis, null);
+  }
+  else {
+    assert.strictEqual(parameter.ellipsis, null);
+  }
+  if (!hasDefaultValue) {
+    assert.strictEqual(parameter.equal, null);
+    assert.strictEqual(parameter.expression, null);
+  }
+  return parameter;
 }
 
 function assertPropertyDeclaration(statements: ISyntaxNode[]): PropertyDeclarationSyntaxNode {
@@ -153,8 +191,6 @@ describe('PhpParser', function() {
       Test.assertDiagnostics(diagnosticTests);
     });
 
-    // Everything except for the parameter list and statement block needs full
-    // testing since it uses a different implementation than `function-declaration`.
     describe('method-declaration', function() {
       let syntaxTests = [
         new ParserTestArgs('trait A { function b() {} }', 'should parse a method declaration', (statements, text) => {
@@ -179,6 +215,87 @@ describe('PhpParser', function() {
           assert.strictEqual(method.returnType, null);
         }),
 
+        // See modifier tests below.
+
+        // See parameter tests below.
+
+        // Return types.
+        new ParserTestArgs('trait A { function b(): C {} }', 'should parse a method declaration with return type', (statements, text) => {
+          let method = assertMethodDeclaration(statements);
+          assert.strictEqual(method.modifiers, null);
+          assert.strictEqual(method.ampersand, null);
+          Test.assertSyntaxToken(method.identifierOrKeyword, text, TokenKind.Identifier, 'b');
+          assert.strictEqual(method.returnType instanceof TypeSyntaxNode, true);
+        }),
+        new ParserTestArgs('trait A { function b(): \\C {} }', 'should parse a method declaration with fully qualified return type', (statements, text) => {
+          let method = assertMethodDeclaration(statements);
+          assert.strictEqual(method.modifiers, null);
+          assert.strictEqual(method.ampersand, null);
+          Test.assertSyntaxToken(method.identifierOrKeyword, text, TokenKind.Identifier, 'b');
+          assert.strictEqual(method.returnType instanceof TypeSyntaxNode, true);
+        }),
+        new ParserTestArgs('trait A { function b(): namespace\\C {} }', 'should parse a method declaration with relative return type', (statements, text) => {
+          let method = assertMethodDeclaration(statements);
+          assert.strictEqual(method.modifiers, null);
+          assert.strictEqual(method.ampersand, null);
+          Test.assertSyntaxToken(method.identifierOrKeyword, text, TokenKind.Identifier, 'b');
+          assert.strictEqual(method.returnType instanceof TypeSyntaxNode, true);
+        }),
+        new ParserTestArgs('trait A { function b(): array {} }', 'should parse a method declaration with predefined return type (array)', (statements, text) => {
+          let method = assertMethodDeclaration(statements);
+          assert.strictEqual(method.modifiers, null);
+          assert.strictEqual(method.ampersand, null);
+          Test.assertSyntaxToken(method.identifierOrKeyword, text, TokenKind.Identifier, 'b');
+          assert.strictEqual(method.returnType instanceof PredefinedTypeSyntaxNode, true);
+        }),
+        new ParserTestArgs('trait A { function b(): callable {} }', 'should parse a method declaration with predefined return type (callable)', (statements, text) => {
+          let method = assertMethodDeclaration(statements);
+          assert.strictEqual(method.modifiers, null);
+          assert.strictEqual(method.ampersand, null);
+          Test.assertSyntaxToken(method.identifierOrKeyword, text, TokenKind.Identifier, 'b');
+          assert.strictEqual(method.returnType instanceof PredefinedTypeSyntaxNode, true);
+        }),
+      ];
+      Test.assertSyntaxNodes(syntaxTests);
+
+      let syntaxTests7_1 = [
+        new ParserTestArgs('trait A { function b(): ? C {} }', 'should parse a method declaration with nullable return type', (statements, text) => {
+          let method = assertMethodDeclaration(statements);
+          assert.strictEqual(method.modifiers, null);
+          assert.strictEqual(method.ampersand, null);
+          Test.assertSyntaxToken(method.identifierOrKeyword, text, TokenKind.Identifier, 'b');
+          let returnType = <NamedTypeSyntaxNode>method.returnType;
+          assert.strictEqual(returnType instanceof NamedTypeSyntaxNode, true, 'NamedTypeSyntaxNode');
+          assert.notStrictEqual(returnType.question, null);
+          assert.strictEqual(returnType.typeName instanceof PartiallyQualifiedNameSyntaxNode, true);
+        }),
+      ];
+      Test.assertSyntaxNodes(syntaxTests7_1, PhpVersion.PHP7_1);
+
+      let diagnosticTests = [
+        new DiagnosticTestArgs('trait A { function }', 'missing method name or ampersand', [ErrorCode.ERR_MethodNameOrAmpersandExpected], [18]),
+        new DiagnosticTestArgs('trait A { function &', 'missing method name (after ampersand)', [ErrorCode.ERR_MethodNameExpected], [20]),
+        new DiagnosticTestArgs('trait A { function b }', 'missing open paren', [ErrorCode.ERR_OpenParenExpected], [20]),
+        new DiagnosticTestArgs('trait A { function b( }', 'missing ampersand, ellipsis, question, type, variable, or close paren', [ErrorCode.ERR_ParameterOrCloseParenExpected], [21]),
+        new DiagnosticTestArgs('trait A { function b() }', 'missing open brace or colon', [ErrorCode.ERR_OpenBraceOrColonExpected], [22]),
+
+        new DiagnosticTestArgs('trait A { function b():', 'missing return type', [ErrorCode.ERR_TypeExpected], [23]),
+        new DiagnosticTestArgs('trait A { function b(): C\\ }', 'missing identifier in return type', [ErrorCode.ERR_IdentifierExpected], [26]),
+        new DiagnosticTestArgs('trait A { function b(): \\ }', 'missing identifier in return type (fully qualified name)', [ErrorCode.ERR_IdentifierExpected], [25]),
+        new DiagnosticTestArgs('trait A { function b(); }', 'should not expect a semicolon after a non-abstract method declaration', [ErrorCode.ERR_OpenBraceOrColonExpected], [22]),
+
+        new DiagnosticTestArgs('trait A { abstract function b() }', 'missing colon or semicolon', [ErrorCode.ERR_ColonOrSemicolonExpected], [31]),
+        new DiagnosticTestArgs('trait A { abstract function b() {} }', 'should not expect method body on abstract method', [ErrorCode.ERR_AbstractMethodHasBody], [32]),
+
+        // @todo These should be recovery tests.
+        new DiagnosticTestArgs('trait A { function b() { }', 'missing close brace', [ErrorCode.ERR_CloseBraceExpected], [26]),
+        new DiagnosticTestArgs('trait A { function b() { public $c; }', 'missing close brace with trailing class member', [ErrorCode.ERR_CloseBraceExpected], [24]),
+      ];
+      Test.assertDiagnostics(diagnosticTests);
+    });
+
+    describe('method-declaration (modifiers)', function() {
+      let syntaxTests = [
         // Modifiers.
         new ParserTestArgs('trait A { abstract function b(); }', 'should parse an abstract method declaration', (statements, text) => {
           let method = assertMethodDeclaration(statements);
@@ -306,82 +423,59 @@ describe('PhpParser', function() {
           Test.assertSyntaxToken(method.identifierOrKeyword, text, TokenKind.Identifier, 'b');
           assert.strictEqual(method.returnType, null);
         }),
+      ];
+      Test.assertSyntaxNodes(syntaxTests);
 
-        // Return types.
-        new ParserTestArgs('trait A { function b(): C {} }', 'should parse a method declaration with return type', (statements, text) => {
-          let method = assertMethodDeclaration(statements);
-          assert.strictEqual(method.modifiers, null);
-          assert.strictEqual(method.ampersand, null);
-          Test.assertSyntaxToken(method.identifierOrKeyword, text, TokenKind.Identifier, 'b');
-          assert.strictEqual(method.returnType instanceof TypeSyntaxNode, true);
-        }),
-        new ParserTestArgs('trait A { function b(): \\C {} }', 'should parse a method declaration with fully qualified return type', (statements, text) => {
-          let method = assertMethodDeclaration(statements);
-          assert.strictEqual(method.modifiers, null);
-          assert.strictEqual(method.ampersand, null);
-          Test.assertSyntaxToken(method.identifierOrKeyword, text, TokenKind.Identifier, 'b');
-          assert.strictEqual(method.returnType instanceof TypeSyntaxNode, true);
-        }),
-        new ParserTestArgs('trait A { function b(): namespace\\C {} }', 'should parse a method declaration with relative return type', (statements, text) => {
-          let method = assertMethodDeclaration(statements);
-          assert.strictEqual(method.modifiers, null);
-          assert.strictEqual(method.ampersand, null);
-          Test.assertSyntaxToken(method.identifierOrKeyword, text, TokenKind.Identifier, 'b');
-          assert.strictEqual(method.returnType instanceof TypeSyntaxNode, true);
-        }),
-        new ParserTestArgs('trait A { function b(): array {} }', 'should parse a method declaration with predefined return type (array)', (statements, text) => {
-          let method = assertMethodDeclaration(statements);
-          assert.strictEqual(method.modifiers, null);
-          assert.strictEqual(method.ampersand, null);
-          Test.assertSyntaxToken(method.identifierOrKeyword, text, TokenKind.Identifier, 'b');
-          assert.strictEqual(method.returnType instanceof PredefinedTypeSyntaxNode, true);
-        }),
-        new ParserTestArgs('trait A { function b(): callable {} }', 'should parse a method declaration with predefined return type (callable)', (statements, text) => {
-          let method = assertMethodDeclaration(statements);
-          assert.strictEqual(method.modifiers, null);
-          assert.strictEqual(method.ampersand, null);
-          Test.assertSyntaxToken(method.identifierOrKeyword, text, TokenKind.Identifier, 'b');
-          assert.strictEqual(method.returnType instanceof PredefinedTypeSyntaxNode, true);
+      let diagnosticTests = [
+        new DiagnosticTestArgs('trait A { abstract final function b(); }', 'should not expect abstract and final modifiers', [ErrorCode.ERR_AbstractMemberIsFinal], [19]),
+        new DiagnosticTestArgs('trait A { abstract private function b(); }', 'should not expect abstract and private modifiers', [ErrorCode.ERR_AbstractMemberIsPrivate], [19]),
+      ];
+      Test.assertDiagnostics(diagnosticTests);
+    });
+
+    describe('method-declaration (parameters)', function() {
+      let syntaxTests = [
+        new ParserTestArgs('trait A { function b($c) {} }', 'should parse a method parameter', (statements) => {
+          let parameters = assertMethodDeclarationWithParameters(statements);
+          assert.strictEqual(parameters.length, 1);
+          assertMethodParameter(parameters[0], false, false, false, false, false);
         }),
       ];
       Test.assertSyntaxNodes(syntaxTests);
 
-      let syntaxTests7_1 = [
-        new ParserTestArgs('trait A { function b(): ? C {} }', 'should parse a method declaration with nullable return type', (statements, text) => {
-          let method = assertMethodDeclaration(statements);
-          assert.strictEqual(method.modifiers, null);
-          assert.strictEqual(method.ampersand, null);
-          Test.assertSyntaxToken(method.identifierOrKeyword, text, TokenKind.Identifier, 'b');
-          let returnType = <NamedTypeSyntaxNode>method.returnType;
-          assert.strictEqual(returnType instanceof NamedTypeSyntaxNode, true, 'NamedTypeSyntaxNode');
-          assert.notStrictEqual(returnType.question, null);
-          assert.strictEqual(returnType.typeName instanceof PartiallyQualifiedNameSyntaxNode, true);
+      let syntaxTests8_0 = [
+        // NOTE: Promoted parameters are allowed on all methods, not just constructors.
+        new ParserTestArgs('trait A { function __construct(public $c) {} }', 'should parse a method parameter with modifier', (statements, text) => {
+          let parameters = assertMethodDeclarationWithParameters(statements);
+          assert.strictEqual(parameters.length, 1);
+          let param = assertMethodParameter(parameters[0], true, false, false, false, false);
+          let modifiers = param.modifiers ? param.modifiers.childTokens() : [];
+          assert.strictEqual(modifiers.length, 1);
+          Test.assertSyntaxToken(modifiers[0], text, TokenKind.Public, 'public');
+        }),
+        new ParserTestArgs('trait A { function b(public static $c) {} }', 'should parse a method parameter with multiple modifiers', (statements, text) => {
+          let parameters = assertMethodDeclarationWithParameters(statements);
+          assert.strictEqual(parameters.length, 1);
+          let param = assertMethodParameter(parameters[0], true, false, false, false, false);
+          let modifiers = param.modifiers ? param.modifiers.childTokens() : [];
+          assert.strictEqual(modifiers.length, 2);
+          Test.assertSyntaxToken(modifiers[0], text, TokenKind.Public, 'public');
+          Test.assertSyntaxToken(modifiers[1], text, TokenKind.Static, 'static');
         }),
       ];
-      Test.assertSyntaxNodes(syntaxTests7_1, PhpVersion.PHP7_1);
+      Test.assertSyntaxNodes(syntaxTests8_0, PhpVersion.PHP8_0);
 
-      let diagnosticTests = [
-        new DiagnosticTestArgs('trait A { function }', 'missing method name or ampersand', [ErrorCode.ERR_MethodNameOrAmpersandExpected], [18]),
-        new DiagnosticTestArgs('trait A { function &', 'missing method name (after ampersand)', [ErrorCode.ERR_MethodNameExpected], [20]),
-        new DiagnosticTestArgs('trait A { function b }', 'missing open paren', [ErrorCode.ERR_OpenParenExpected], [20]),
-        new DiagnosticTestArgs('trait A { function b( }', 'missing ampersand, ellipsis, question, type, variable, or close paren', [ErrorCode.ERR_ParameterOrCloseParenExpected], [21]),
-        new DiagnosticTestArgs('trait A { function b() }', 'missing open brace or colon', [ErrorCode.ERR_OpenBraceOrColonExpected], [22]),
-
-        new DiagnosticTestArgs('trait A { function b():', 'missing return type', [ErrorCode.ERR_TypeExpected], [23]),
-        new DiagnosticTestArgs('trait A { function b(): C\\ }', 'missing identifier in return type', [ErrorCode.ERR_IdentifierExpected], [26]),
-        new DiagnosticTestArgs('trait A { function b(): \\ }', 'missing identifier in return type (fully qualified name)', [ErrorCode.ERR_IdentifierExpected], [25]),
-        new DiagnosticTestArgs('trait A { function b(); }', 'should not expect a semicolon after a non-abstract method declaration', [ErrorCode.ERR_OpenBraceOrColonExpected], [22]),
-
-        new DiagnosticTestArgs('trait A { abstract function b() }', 'missing colon or semicolon', [ErrorCode.ERR_ColonOrSemicolonExpected], [31]),
-        new DiagnosticTestArgs('trait A { abstract function b() {} }', 'should not expect method body on abstract method', [ErrorCode.ERR_AbstractMethodHasBody], [32]),
-        new DiagnosticTestArgs('trait A { abstract final function b(); }', 'should not expect abstract and final modifiers', [ErrorCode.ERR_AbstractMemberIsFinal], [19]),
-        new DiagnosticTestArgs('trait A { abstract private function b(); }', 'should not expect abstract and private modifiers', [ErrorCode.ERR_AbstractMemberIsPrivate], [19]),
-
-        // @todo These should be recovery tests.
-        new DiagnosticTestArgs('trait A { function b() { }', 'missing close brace', [ErrorCode.ERR_CloseBraceExpected], [26]),
-        new DiagnosticTestArgs('trait A { function b() { public $c; }', 'missing close brace with trailing class member', [ErrorCode.ERR_CloseBraceExpected], [24]),
+      let diagnosticTests8_0 = [
+        new DiagnosticTestArgs('trait A { function b(', 'missing ampersand, ellipsis, question, modifier, type, variable, or close paren', [ErrorCode.ERR_ParameterOrCloseParenExpected], [21]),
+        new DiagnosticTestArgs('trait A { function b(public', 'missing ampersand, ellipsis, question, type, variable, or close paren', [ErrorCode.ERR_ParameterExpected], [27]),
       ];
-      Test.assertDiagnostics(diagnosticTests);
+      Test.assertDiagnostics(diagnosticTests8_0, PhpVersion.PHP8_0);
+
+      let diagnosticRegressionTests8_0 = [
+        new DiagnosticTestArgs('trait A { function b(', 'missing ampersand, ellipsis, question, type, variable, or close paren', [ErrorCode.ERR_ParameterOrCloseParenExpected], [21]),
+        new DiagnosticTestArgs('trait A { function b(public', 'should not parse a modifier', [ErrorCode.ERR_FeatureConstructorParameterPromotion, ErrorCode.ERR_ParameterExpected], [21, 27]),
+      ];
+      Test.assertDiagnostics(diagnosticRegressionTests8_0, PhpVersion.PHP7_0, PhpVersion.PHP7_4);
     });
 
     describe('property-declaration', function() {

--- a/test/src/parser/PhpParserTest_TraitDeclaration.ts
+++ b/test/src/parser/PhpParserTest_TraitDeclaration.ts
@@ -140,7 +140,7 @@ describe('PhpParser', function() {
       }),
       new ParserTestArgs('{ trait A {} }', 'should parse a trait declaration in statement block', (statements) => {
         let block = <StatementBlockSyntaxNode>statements[0];
-        assert.strictEqual(block instanceof StatementBlockSyntaxNode, true, 'is a StatementBlockSyntaxNode');
+        assert.strictEqual(block instanceof StatementBlockSyntaxNode, true, 'StatementBlockSyntaxNode');
         let innerStatements = block.childNodes();
         assert.strictEqual(innerStatements.length, 1);
         assert.strictEqual(innerStatements[0] instanceof TraitDeclarationSyntaxNode, true);

--- a/test/src/parser/PhpParserTest_TraitDeclaration.ts
+++ b/test/src/parser/PhpParserTest_TraitDeclaration.ts
@@ -57,7 +57,7 @@ function assertMethodDeclaration(statements: ISyntaxNode[]): MethodDeclarationSy
   let members = traitNode.members ? traitNode.members.childNodes() : [];
   assert.strictEqual(members.length, 1);
   let method = <MethodDeclarationSyntaxNode>members[0];
-  assert.strictEqual(method instanceof MethodDeclarationSyntaxNode, true);
+  assert.strictEqual(method instanceof MethodDeclarationSyntaxNode, true, 'MethodDeclarationSyntaxNode');
   return method;
 }
 
@@ -104,8 +104,19 @@ function assertPropertyDeclaration(statements: ISyntaxNode[]): PropertyDeclarati
   let members = traitNode.members ? traitNode.members.childNodes() : [];
   assert.strictEqual(members.length, 1);
   let property = <PropertyDeclarationSyntaxNode>members[0];
-  assert.strictEqual(property instanceof PropertyDeclarationSyntaxNode, true);
+  assert.strictEqual(property instanceof PropertyDeclarationSyntaxNode, true, 'PropertyDeclarationSyntaxNode');
   return property;
+}
+
+function assertPropertyElements(node: PropertyDeclarationSyntaxNode, text: string, expected: string[]): void {
+  let elements = node.properties.childNodes();
+  assert.strictEqual(elements.length, expected.length);
+  for (let i = 0; i < elements.length; i++) {
+    let element = <PropertyElementSyntaxNode>elements[i];
+    assert.strictEqual(element instanceof PropertyElementSyntaxNode, true, 'PropertyElementSyntaxNode');
+    Test.assertSyntaxToken(element.variable, text, TokenKind.Variable, expected[i]);
+    assert.strictEqual(element.expression, null);
+  }
 }
 
 function assertTraitUse(statements: ISyntaxNode[]): TraitUseSyntaxNode {
@@ -114,7 +125,7 @@ function assertTraitUse(statements: ISyntaxNode[]): TraitUseSyntaxNode {
   let members = traitNode.members ? traitNode.members.childNodes() : [];
   assert.strictEqual(members.length, 1);
   let traitUse = <TraitUseSyntaxNode>members[0];
-  assert.strictEqual(traitUse instanceof TraitUseSyntaxNode, true);
+  assert.strictEqual(traitUse instanceof TraitUseSyntaxNode, true, 'TraitUseSyntaxNode');
   return traitUse;
 }
 
@@ -124,7 +135,7 @@ function assertTraitUseGroup(statements: ISyntaxNode[]): TraitUseGroupSyntaxNode
   let members = traitNode.members ? traitNode.members.childNodes() : [];
   assert.strictEqual(members.length, 1);
   let traitUseGroup = <TraitUseGroupSyntaxNode>members[0];
-  assert.strictEqual(traitUseGroup instanceof TraitUseGroupSyntaxNode, true);
+  assert.strictEqual(traitUseGroup instanceof TraitUseGroupSyntaxNode, true, 'TraitUseGroupSyntaxNode');
   return traitUseGroup;
 }
 
@@ -486,12 +497,7 @@ describe('PhpParser', function() {
           assert.strictEqual(modifiers.length, 1);
           Test.assertSyntaxToken(modifiers[0], text, TokenKind.Public, 'public');
           assert.strictEqual(declNode.type, null);
-          let elements = declNode.properties ? declNode.properties.childNodes() : [];
-          assert.strictEqual(elements.length, 1);
-          let propertyNode = <PropertyElementSyntaxNode>elements[0];
-          assert.strictEqual(propertyNode instanceof PropertyElementSyntaxNode, true);
-          Test.assertSyntaxToken(propertyNode.variable, text, TokenKind.Variable, '$b');
-          assert.strictEqual(propertyNode.expression, null);
+          assertPropertyElements(declNode, text, ['$b']);
         }),
         new ParserTestArgs('trait A { var $b; }', 'should parse a property declaration (var)', (statements, text) => {
           let declNode = assertPropertyDeclaration(statements);
@@ -499,12 +505,7 @@ describe('PhpParser', function() {
           assert.strictEqual(modifiers.length, 1);
           Test.assertSyntaxToken(modifiers[0], text, TokenKind.Var, 'var');
           assert.strictEqual(declNode.type, null);
-          let elements = declNode.properties ? declNode.properties.childNodes() : [];
-          assert.strictEqual(elements.length, 1);
-          let propertyNode = <PropertyElementSyntaxNode>elements[0];
-          assert.strictEqual(propertyNode instanceof PropertyElementSyntaxNode, true);
-          Test.assertSyntaxToken(propertyNode.variable, text, TokenKind.Variable, '$b');
-          assert.strictEqual(propertyNode.expression, null);
+          assertPropertyElements(declNode, text, ['$b']);
         }),
         new ParserTestArgs('trait A { public $b = 1; }', 'should parse a property declaration with assignment', (statements, text) => {
           let declNode = assertPropertyDeclaration(statements);
@@ -525,16 +526,7 @@ describe('PhpParser', function() {
           assert.strictEqual(modifiers.length, 1);
           Test.assertSyntaxToken(modifiers[0], text, TokenKind.Public, 'public');
           assert.strictEqual(declNode.type, null);
-          let elements = declNode.properties ? declNode.properties.childNodes() : [];
-          assert.strictEqual(elements.length, 2);
-          let firstProperty = <PropertyElementSyntaxNode>elements[0];
-          assert.strictEqual(firstProperty instanceof PropertyElementSyntaxNode, true);
-          Test.assertSyntaxToken(firstProperty.variable, text, TokenKind.Variable, '$b');
-          assert.strictEqual(firstProperty.expression, null);
-          let secondProperty = <PropertyElementSyntaxNode>elements[1];
-          assert.strictEqual(secondProperty instanceof PropertyElementSyntaxNode, true);
-          Test.assertSyntaxToken(secondProperty.variable, text, TokenKind.Variable, '$c');
-          assert.strictEqual(secondProperty.expression, null);
+          assertPropertyElements(declNode, text, ['$b', '$c']);
         }),
         new ParserTestArgs('trait A { protected $b; }', 'should parse a protected property declaration', (statements, text) => {
           let declNode = assertPropertyDeclaration(statements);
@@ -542,12 +534,7 @@ describe('PhpParser', function() {
           assert.strictEqual(modifiers.length, 1);
           Test.assertSyntaxToken(modifiers[0], text, TokenKind.Protected, 'protected');
           assert.strictEqual(declNode.type, null);
-          let elements = declNode.properties ? declNode.properties.childNodes() : [];
-          assert.strictEqual(elements.length, 1);
-          let propertyNode = <PropertyElementSyntaxNode>elements[0];
-          assert.strictEqual(propertyNode instanceof PropertyElementSyntaxNode, true);
-          Test.assertSyntaxToken(propertyNode.variable, text, TokenKind.Variable, '$b');
-          assert.strictEqual(propertyNode.expression, null);
+          assertPropertyElements(declNode, text, ['$b']);
         }),
         new ParserTestArgs('trait A { private $b; }', 'should parse a private property declaration', (statements, text) => {
           let declNode = assertPropertyDeclaration(statements);
@@ -555,12 +542,7 @@ describe('PhpParser', function() {
           assert.strictEqual(modifiers.length, 1);
           Test.assertSyntaxToken(modifiers[0], text, TokenKind.Private, 'private');
           assert.strictEqual(declNode.type, null);
-          let elements = declNode.properties ? declNode.properties.childNodes() : [];
-          assert.strictEqual(elements.length, 1);
-          let propertyNode = <PropertyElementSyntaxNode>elements[0];
-          assert.strictEqual(propertyNode instanceof PropertyElementSyntaxNode, true);
-          Test.assertSyntaxToken(propertyNode.variable, text, TokenKind.Variable, '$b');
-          assert.strictEqual(propertyNode.expression, null);
+          assertPropertyElements(declNode, text, ['$b']);
         }),
         new ParserTestArgs('trait A { static $b; }', 'should parse a static property declaration', (statements, text) => {
           let declNode = assertPropertyDeclaration(statements);
@@ -568,12 +550,7 @@ describe('PhpParser', function() {
           assert.strictEqual(modifiers.length, 1);
           Test.assertSyntaxToken(modifiers[0], text, TokenKind.Static, 'static');
           assert.strictEqual(declNode.type, null);
-          let elements = declNode.properties ? declNode.properties.childNodes() : [];
-          assert.strictEqual(elements.length, 1);
-          let propertyNode = <PropertyElementSyntaxNode>elements[0];
-          assert.strictEqual(propertyNode instanceof PropertyElementSyntaxNode, true);
-          Test.assertSyntaxToken(propertyNode.variable, text, TokenKind.Variable, '$b');
-          assert.strictEqual(propertyNode.expression, null);
+          assertPropertyElements(declNode, text, ['$b']);
         }),
         new ParserTestArgs('trait A { public static $b; }', 'should parse a static property declaration with visibility modifier (before)', (statements, text) => {
           let declNode = assertPropertyDeclaration(statements);
@@ -582,12 +559,7 @@ describe('PhpParser', function() {
           Test.assertSyntaxToken(modifiers[0], text, TokenKind.Public, 'public');
           Test.assertSyntaxToken(modifiers[1], text, TokenKind.Static, 'static');
           assert.strictEqual(declNode.type, null);
-          let elements = declNode.properties ? declNode.properties.childNodes() : [];
-          assert.strictEqual(elements.length, 1);
-          let propertyNode = <PropertyElementSyntaxNode>elements[0];
-          assert.strictEqual(propertyNode instanceof PropertyElementSyntaxNode, true);
-          Test.assertSyntaxToken(propertyNode.variable, text, TokenKind.Variable, '$b');
-          assert.strictEqual(propertyNode.expression, null);
+          assertPropertyElements(declNode, text, ['$b']);
         }),
         new ParserTestArgs('trait A { static public $b; }', 'should parse a static property declaration with visibility modifier (after)', (statements, text) => {
           let declNode = assertPropertyDeclaration(statements);
@@ -596,12 +568,7 @@ describe('PhpParser', function() {
           Test.assertSyntaxToken(modifiers[0], text, TokenKind.Static, 'static');
           Test.assertSyntaxToken(modifiers[1], text, TokenKind.Public, 'public');
           assert.strictEqual(declNode.type, null);
-          let elements = declNode.properties ? declNode.properties.childNodes() : [];
-          assert.strictEqual(elements.length, 1);
-          let propertyNode = <PropertyElementSyntaxNode>elements[0];
-          assert.strictEqual(propertyNode instanceof PropertyElementSyntaxNode, true);
-          Test.assertSyntaxToken(propertyNode.variable, text, TokenKind.Variable, '$b');
-          assert.strictEqual(propertyNode.expression, null);
+          assertPropertyElements(declNode, text, ['$b']);
         }),
       ];
       Test.assertSyntaxNodes(syntaxTests);
@@ -612,84 +579,54 @@ describe('PhpParser', function() {
           let modifiers = declNode.modifiers ? declNode.modifiers.childTokens() : [];
           assert.strictEqual(modifiers.length, 1);
           Test.assertSyntaxToken(modifiers[0], text, TokenKind.Public, 'public');
-          assert.notStrictEqual(declNode.type, null);
-          assert.strictEqual(declNode.type ? declNode.type.question : false, null);
-          let elements = declNode.properties ? declNode.properties.childNodes() : [];
-          assert.strictEqual(elements.length, 1);
-          let propertyNode = <PropertyElementSyntaxNode>elements[0];
-          assert.strictEqual(propertyNode instanceof PropertyElementSyntaxNode, true);
-          Test.assertSyntaxToken(propertyNode.variable, text, TokenKind.Variable, '$c');
-          assert.strictEqual(propertyNode.expression, null);
+          assert.strictEqual(declNode.type instanceof NamedTypeSyntaxNode, true, 'NamedTypeSyntaxNode');
+          assert.strictEqual((<NamedTypeSyntaxNode>declNode.type).question, null);
+          assertPropertyElements(declNode, text, ['$c']);
         }),
         new ParserTestArgs('trait A { var B $c; }', 'should parse a typed property declaration (var)', (statements, text) => {
           let declNode = assertPropertyDeclaration(statements);
           let modifiers = declNode.modifiers ? declNode.modifiers.childTokens() : [];
           assert.strictEqual(modifiers.length, 1);
           Test.assertSyntaxToken(modifiers[0], text, TokenKind.Var, 'var');
-          assert.notStrictEqual(declNode.type, null);
-          assert.strictEqual(declNode.type ? declNode.type.question : false, null);
-          let elements = declNode.properties ? declNode.properties.childNodes() : [];
-          assert.strictEqual(elements.length, 1);
-          let propertyNode = <PropertyElementSyntaxNode>elements[0];
-          assert.strictEqual(propertyNode instanceof PropertyElementSyntaxNode, true);
-          Test.assertSyntaxToken(propertyNode.variable, text, TokenKind.Variable, '$c');
-          assert.strictEqual(propertyNode.expression, null);
+          assert.strictEqual(declNode.type instanceof NamedTypeSyntaxNode, true, 'NamedTypeSyntaxNode');
+          assert.strictEqual((<NamedTypeSyntaxNode>declNode.type).question, null);
+          assertPropertyElements(declNode, text, ['$c']);
         }),
         new ParserTestArgs('trait A { public \\B $c; }', 'should parse a typed property declaration with fully qualified name', (statements, text) => {
           let declNode = assertPropertyDeclaration(statements);
           let modifiers = declNode.modifiers ? declNode.modifiers.childTokens() : [];
           assert.strictEqual(modifiers.length, 1);
           Test.assertSyntaxToken(modifiers[0], text, TokenKind.Public, 'public');
-          assert.notStrictEqual(declNode.type, null);
-          assert.strictEqual(declNode.type ? declNode.type.question : false, null);
-          let elements = declNode.properties ? declNode.properties.childNodes() : [];
-          assert.strictEqual(elements.length, 1);
-          let propertyNode = <PropertyElementSyntaxNode>elements[0];
-          assert.strictEqual(propertyNode instanceof PropertyElementSyntaxNode, true);
-          Test.assertSyntaxToken(propertyNode.variable, text, TokenKind.Variable, '$c');
-          assert.strictEqual(propertyNode.expression, null);
+          assert.strictEqual(declNode.type instanceof NamedTypeSyntaxNode, true, 'NamedTypeSyntaxNode');
+          assert.strictEqual((<NamedTypeSyntaxNode>declNode.type).question, null);
+          assertPropertyElements(declNode, text, ['$c']);
         }),
         new ParserTestArgs('trait A { public namespace\\B $c; }', 'should parse a typed property declaration with relative name', (statements, text) => {
           let declNode = assertPropertyDeclaration(statements);
           let modifiers = declNode.modifiers ? declNode.modifiers.childTokens() : [];
           assert.strictEqual(modifiers.length, 1);
           Test.assertSyntaxToken(modifiers[0], text, TokenKind.Public, 'public');
-          assert.notStrictEqual(declNode.type, null);
-          assert.strictEqual(declNode.type ? declNode.type.question : false, null);
-          let elements = declNode.properties ? declNode.properties.childNodes() : [];
-          assert.strictEqual(elements.length, 1);
-          let propertyNode = <PropertyElementSyntaxNode>elements[0];
-          assert.strictEqual(propertyNode instanceof PropertyElementSyntaxNode, true);
-          Test.assertSyntaxToken(propertyNode.variable, text, TokenKind.Variable, '$c');
-          assert.strictEqual(propertyNode.expression, null);
+          assert.strictEqual(declNode.type instanceof NamedTypeSyntaxNode, true, 'NamedTypeSyntaxNode');
+          assert.strictEqual((<NamedTypeSyntaxNode>declNode.type).question, null);
+          assertPropertyElements(declNode, text, ['$c']);
         }),
         new ParserTestArgs('trait A { public array $c; }', 'should parse a property declaration with predefined type', (statements, text) => {
           let declNode = assertPropertyDeclaration(statements);
           let modifiers = declNode.modifiers ? declNode.modifiers.childTokens() : [];
           assert.strictEqual(modifiers.length, 1);
           Test.assertSyntaxToken(modifiers[0], text, TokenKind.Public, 'public');
-          assert.notStrictEqual(declNode.type, null);
-          assert.strictEqual(declNode.type ? declNode.type.question : false, null);
-          let elements = declNode.properties ? declNode.properties.childNodes() : [];
-          assert.strictEqual(elements.length, 1);
-          let propertyNode = <PropertyElementSyntaxNode>elements[0];
-          assert.strictEqual(propertyNode instanceof PropertyElementSyntaxNode, true);
-          Test.assertSyntaxToken(propertyNode.variable, text, TokenKind.Variable, '$c');
-          assert.strictEqual(propertyNode.expression, null);
+          assert.strictEqual(declNode.type instanceof PredefinedTypeSyntaxNode, true, 'PredefinedTypeSyntaxNode');
+          assert.strictEqual((<PredefinedTypeSyntaxNode>declNode.type).question, null);
+          assertPropertyElements(declNode, text, ['$c']);
         }),
         new ParserTestArgs('trait A { public ?B $c; }', 'should parse a property declaration with nullable type', (statements, text) => {
           let declNode = assertPropertyDeclaration(statements);
           let modifiers = declNode.modifiers ? declNode.modifiers.childTokens() : [];
           assert.strictEqual(modifiers.length, 1);
           Test.assertSyntaxToken(modifiers[0], text, TokenKind.Public, 'public');
-          assert.notStrictEqual(declNode.type, null);
-          assert.notStrictEqual(declNode.type ? declNode.type.question : false, null);
-          let elements = declNode.properties ? declNode.properties.childNodes() : [];
-          assert.strictEqual(elements.length, 1);
-          let propertyNode = <PropertyElementSyntaxNode>elements[0];
-          assert.strictEqual(propertyNode instanceof PropertyElementSyntaxNode, true);
-          Test.assertSyntaxToken(propertyNode.variable, text, TokenKind.Variable, '$c');
-          assert.strictEqual(propertyNode.expression, null);
+          assert.strictEqual(declNode.type instanceof NamedTypeSyntaxNode, true, 'NamedTypeSyntaxNode');
+          assert.notStrictEqual((<NamedTypeSyntaxNode>declNode.type).question, null);
+          assertPropertyElements(declNode, text, ['$c']);
         }),
       ];
       Test.assertSyntaxNodes(syntaxTests7_4, PhpVersion.PHP7_4);

--- a/test/src/parser/PhpParserTest_TraitDeclaration.ts
+++ b/test/src/parser/PhpParserTest_TraitDeclaration.ts
@@ -284,6 +284,13 @@ describe('PhpParser', function() {
       Test.assertSyntaxNodes(syntaxTests7_1, PhpVersion.PHP7_1);
 
       let syntaxTests8_0 = [
+        new ParserTestArgs('trait A { function b(): static {} }', 'should parse a method declaration with static return type', (statements, text) => {
+          let method = assertMethodDeclaration(statements);
+          assert.strictEqual(method.modifiers, null);
+          assert.strictEqual(method.ampersand, null);
+          Test.assertSyntaxToken(method.identifierOrKeyword, text, TokenKind.Identifier, 'b');
+          assert.strictEqual(method.returnType instanceof PredefinedTypeSyntaxNode, true, 'PredefinedTypeSyntaxNode');
+        }),
         new ParserTestArgs('trait A { function b(): array | C {} }', 'should parse a method declaration with type union', (statements, text) => {
           let method = assertMethodDeclaration(statements);
           assert.strictEqual(method.modifiers, null);
@@ -327,6 +334,7 @@ describe('PhpParser', function() {
       let diagnosticRegressionTests8_0 = [
         new DiagnosticTestArgs('trait A { function b(): C }', 'missing open brace', [ErrorCode.ERR_OpenBraceExpected], [25]),
         new DiagnosticTestArgs('trait A { function b(): C | D {} }', 'should not parse a type union', [ErrorCode.ERR_FeatureUnionTypes], [24]),
+        new DiagnosticTestArgs('trait A { function b(): static {} }', 'should not parse a static return type', [ErrorCode.ERR_FeatureStaticReturnType], [24]),
         new DiagnosticTestArgs('trait A { abstract function b(): C }', 'missing semicolon', [ErrorCode.ERR_SemicolonExpected], [34]),
       ];
       Test.assertDiagnostics(diagnosticRegressionTests8_0, PhpVersion.PHP7_0, PhpVersion.PHP7_4);

--- a/test/src/parser/PhpParserTest_UseDeclaration.ts
+++ b/test/src/parser/PhpParserTest_UseDeclaration.ts
@@ -191,6 +191,99 @@ describe('PhpParser', function() {
       Test.assertDiagnostics(diagnosticTests);
     });
 
+    describe('use-group-declaration', function() {
+      let syntaxTests = [
+        new ParserTestArgs('use A\\{ function B };', 'should parse a mixed use group declaration', (statements, text) => {
+          let useDecl = <UseGroupDeclarationSyntaxNode>statements[0];
+          let declarations = assertUseGroupDeclaration(useDecl, 2, false);
+          assert.strictEqual(declarations.length, 1);
+          assertUseElement(declarations[0], text, false, 'function', null);
+        }),
+        new ParserTestArgs('use A\\{ function B, function C };', 'should parse a mixed use group declaration with multiple imports', (statements, text) => {
+          let useDecl = <UseGroupDeclarationSyntaxNode>statements[0];
+          let declarations = assertUseGroupDeclaration(useDecl, 2, false);
+          assert.strictEqual(declarations.length, 2);
+          assertUseElement(declarations[0], text, false, 'function', null);
+          assertUseElement(declarations[1], text, false, 'function', null);
+        }),
+        new ParserTestArgs('use A\\{ function B, function C as D };', 'should parse a mixed use group declaration with aliased function name', (statements, text) => {
+          let useDecl = <UseGroupDeclarationSyntaxNode>statements[0];
+          let declarations = assertUseGroupDeclaration(useDecl, 2, false);
+          assert.strictEqual(declarations.length, 2);
+          assertUseElement(declarations[0], text, false, 'function', null);
+          assertUseElement(declarations[1], text, false, 'function', 'D');
+        }),
+        new ParserTestArgs('use A\\{ function B, const C };', 'should parse a mixed use group declaration with function and constant import types', (statements, text) => {
+          let useDecl = <UseGroupDeclarationSyntaxNode>statements[0];
+          let declarations = assertUseGroupDeclaration(useDecl, 2, false);
+          assert.strictEqual(declarations.length, 2);
+          assertUseElement(declarations[0], text, false, 'function', null);
+          assertUseElement(declarations[1], text, false, 'const', null);
+        }),
+        new ParserTestArgs('use A\\{ function B, const C as D };', 'should parse a mixed use group declaration with aliased constant name', (statements, text) => {
+          let useDecl = <UseGroupDeclarationSyntaxNode>statements[0];
+          let declarations = assertUseGroupDeclaration(useDecl, 2, false);
+          assert.strictEqual(declarations.length, 2);
+          assertUseElement(declarations[0], text, false, 'function', null);
+          assertUseElement(declarations[1], text, false, 'const', 'D');
+        }),
+        new ParserTestArgs('use A\\{ function B, C };', 'should parse a mixed use group declaration with function and class import types', (statements, text) => {
+          let useDecl = <UseGroupDeclarationSyntaxNode>statements[0];
+          let declarations = assertUseGroupDeclaration(useDecl, 2, false);
+          assert.strictEqual(declarations.length, 2);
+          assertUseElement(declarations[0], text, false, 'function', null);
+          assertUseElement(declarations[1], text, false, null, null);
+        }),
+        new ParserTestArgs('use A\\{ function B\\C };', 'should parse a mixed use group declaration with partially qualified import', (statements, text) => {
+          let useDecl = <UseGroupDeclarationSyntaxNode>statements[0];
+          let declarations = assertUseGroupDeclaration(useDecl, 2, false);
+          assert.strictEqual(declarations.length, 1);
+          assertUseElement(declarations[0], text, false, 'function', null);
+        }),
+        new ParserTestArgs('use \\A\\{ function B };', 'should parse a mixed use group declaration with fully qualified root name', (statements, text) => {
+          let useDecl = <UseGroupDeclarationSyntaxNode>statements[0];
+          let declarations = assertUseGroupDeclaration(useDecl, 3, false);
+          assert.strictEqual(declarations.length, 1);
+          assertUseElement(declarations[0], text, false, 'function', null);
+        }),
+      ];
+      Test.assertSyntaxNodes(syntaxTests);
+
+      let syntaxTests7_2 = [
+        new ParserTestArgs('use A\\{ function B, };', 'should parse a mixed use group declaration with trailing comma', (statements, text) => {
+          let useDecl = <UseGroupDeclarationSyntaxNode>statements[0];
+          let declarations = assertUseGroupDeclaration(useDecl, 2, false);
+          assert.strictEqual(declarations.length, 1);
+          assertUseElement(declarations[0], text, false, 'function', null);
+        }),
+      ];
+      Test.assertSyntaxNodes(syntaxTests7_2, PhpVersion.PHP7_2);
+
+      let diagnosticTests = [
+        new DiagnosticTestArgs('use A\\{', 'missing identifier or import type', [ErrorCode.ERR_UseTypeExpected], [7]),
+
+        new DiagnosticTestArgs('use A\\{ function', 'missing identifier', [ErrorCode.ERR_IdentifierExpected], [16]),
+        new DiagnosticTestArgs('use A\\{ function B', 'missing as, backslash, comma, or close brace', [ErrorCode.ERR_IncompleteUseGroupDeclaration], [18]),
+        new DiagnosticTestArgs('use A\\{ function B as', 'missing identifier (alias)', [ErrorCode.ERR_IdentifierExpected], [21]),
+        new DiagnosticTestArgs('use A\\{ function B as C', 'missing comma or close brace', [ErrorCode.ERR_CommaOrCloseBraceExpected], [23]),
+
+        new DiagnosticTestArgs('use A\\{ function \\B', 'should not parse a fully qualified function name', [ErrorCode.ERR_IdentifierExpected], [16]),
+      ];
+      Test.assertDiagnostics(diagnosticTests);
+
+      let diagnosticTests7_2 = [
+        new DiagnosticTestArgs('use A\\{ function B,', 'missing identifier, import type, or close brace', [ErrorCode.ERR_UseTypeOrCloseBraceExpected], [19]),
+        new DiagnosticTestArgs('use A\\{ function B as C,', 'missing identifier, import type, or close brace (after alias)', [ErrorCode.ERR_UseTypeOrCloseBraceExpected], [24]),
+      ];
+      Test.assertDiagnostics(diagnosticTests7_2, PhpVersion.PHP7_2);
+
+      let featureTrailingCommas = [
+        new DiagnosticTestArgs('use A\\{ function B, };', 'should not parse trailing comma in mixed type import', [ErrorCode.ERR_FeatureTrailingCommasInUseDeclarations], [18]),
+        new DiagnosticTestArgs('use A\\{ function B as C, };', 'should not parse trailing comma in mixed type import (after alias)', [ErrorCode.ERR_FeatureTrailingCommasInUseDeclarations], [23]),
+      ];
+      Test.assertDiagnostics(featureTrailingCommas, PhpVersion.PHP7_0, PhpVersion.PHP7_1);
+    });
+
     describe('use-group-declaration (with type)', function() {
       let syntaxTests = [
         new ParserTestArgs('use function A\\{ B };', 'should parse a use function group declaration', (statements, text) => {
@@ -309,99 +402,6 @@ describe('PhpParser', function() {
         new DiagnosticTestArgs('use function A\\{ B, };', 'should not parse trailing comma in function import (completed)', [ErrorCode.ERR_FeatureTrailingCommasInUseDeclarations], [18]),
         new DiagnosticTestArgs('use const A\\{ B,', 'should not parse trailing comma in constant import', [ErrorCode.ERR_FeatureTrailingCommasInUseDeclarations, ErrorCode.ERR_IdentifierOrCloseBraceExpected], [15, 16]),
         new DiagnosticTestArgs('use const A\\{ B, };', 'should not parse trailing comma in constant import (completed)', [ErrorCode.ERR_FeatureTrailingCommasInUseDeclarations], [15]),
-      ];
-      Test.assertDiagnostics(featureTrailingCommas, PhpVersion.PHP7_0, PhpVersion.PHP7_1);
-    });
-
-    describe('use-group-declaration (mixed types)', function() {
-      let syntaxTests = [
-        new ParserTestArgs('use A\\{ function B };', 'should parse a mixed use group declaration', (statements, text) => {
-          let useDecl = <UseGroupDeclarationSyntaxNode>statements[0];
-          let declarations = assertUseGroupDeclaration(useDecl, 2, false);
-          assert.strictEqual(declarations.length, 1);
-          assertUseElement(declarations[0], text, false, 'function', null);
-        }),
-        new ParserTestArgs('use A\\{ function B, function C };', 'should parse a mixed use group declaration with multiple imports', (statements, text) => {
-          let useDecl = <UseGroupDeclarationSyntaxNode>statements[0];
-          let declarations = assertUseGroupDeclaration(useDecl, 2, false);
-          assert.strictEqual(declarations.length, 2);
-          assertUseElement(declarations[0], text, false, 'function', null);
-          assertUseElement(declarations[1], text, false, 'function', null);
-        }),
-        new ParserTestArgs('use A\\{ function B, function C as D };', 'should parse a mixed use group declaration with aliased function name', (statements, text) => {
-          let useDecl = <UseGroupDeclarationSyntaxNode>statements[0];
-          let declarations = assertUseGroupDeclaration(useDecl, 2, false);
-          assert.strictEqual(declarations.length, 2);
-          assertUseElement(declarations[0], text, false, 'function', null);
-          assertUseElement(declarations[1], text, false, 'function', 'D');
-        }),
-        new ParserTestArgs('use A\\{ function B, const C };', 'should parse a mixed use group declaration with function and constant import types', (statements, text) => {
-          let useDecl = <UseGroupDeclarationSyntaxNode>statements[0];
-          let declarations = assertUseGroupDeclaration(useDecl, 2, false);
-          assert.strictEqual(declarations.length, 2);
-          assertUseElement(declarations[0], text, false, 'function', null);
-          assertUseElement(declarations[1], text, false, 'const', null);
-        }),
-        new ParserTestArgs('use A\\{ function B, const C as D };', 'should parse a mixed use group declaration with aliased constant name', (statements, text) => {
-          let useDecl = <UseGroupDeclarationSyntaxNode>statements[0];
-          let declarations = assertUseGroupDeclaration(useDecl, 2, false);
-          assert.strictEqual(declarations.length, 2);
-          assertUseElement(declarations[0], text, false, 'function', null);
-          assertUseElement(declarations[1], text, false, 'const', 'D');
-        }),
-        new ParserTestArgs('use A\\{ function B, C };', 'should parse a mixed use group declaration with function and class import types', (statements, text) => {
-          let useDecl = <UseGroupDeclarationSyntaxNode>statements[0];
-          let declarations = assertUseGroupDeclaration(useDecl, 2, false);
-          assert.strictEqual(declarations.length, 2);
-          assertUseElement(declarations[0], text, false, 'function', null);
-          assertUseElement(declarations[1], text, false, null, null);
-        }),
-        new ParserTestArgs('use A\\{ function B\\C };', 'should parse a mixed use group declaration with partially qualified import', (statements, text) => {
-          let useDecl = <UseGroupDeclarationSyntaxNode>statements[0];
-          let declarations = assertUseGroupDeclaration(useDecl, 2, false);
-          assert.strictEqual(declarations.length, 1);
-          assertUseElement(declarations[0], text, false, 'function', null);
-        }),
-        new ParserTestArgs('use \\A\\{ function B };', 'should parse a mixed use group declaration with fully qualified root name', (statements, text) => {
-          let useDecl = <UseGroupDeclarationSyntaxNode>statements[0];
-          let declarations = assertUseGroupDeclaration(useDecl, 3, false);
-          assert.strictEqual(declarations.length, 1);
-          assertUseElement(declarations[0], text, false, 'function', null);
-        }),
-      ];
-      Test.assertSyntaxNodes(syntaxTests);
-
-      let syntaxTests7_2 = [
-        new ParserTestArgs('use A\\{ function B, };', 'should parse a mixed use group declaration with trailing comma', (statements, text) => {
-          let useDecl = <UseGroupDeclarationSyntaxNode>statements[0];
-          let declarations = assertUseGroupDeclaration(useDecl, 2, false);
-          assert.strictEqual(declarations.length, 1);
-          assertUseElement(declarations[0], text, false, 'function', null);
-        }),
-      ];
-      Test.assertSyntaxNodes(syntaxTests7_2, PhpVersion.PHP7_2);
-
-      let diagnosticTests = [
-        new DiagnosticTestArgs('use A\\{', 'missing identifier or import type', [ErrorCode.ERR_UseTypeExpected], [7]),
-
-        new DiagnosticTestArgs('use A\\{ function', 'missing identifier', [ErrorCode.ERR_IdentifierExpected], [16]),
-        new DiagnosticTestArgs('use A\\{ function B', 'missing as, backslash, comma, or close brace', [ErrorCode.ERR_IncompleteUseGroupDeclaration], [18]),
-        new DiagnosticTestArgs('use A\\{ function B as', 'missing identifier (alias)', [ErrorCode.ERR_IdentifierExpected], [21]),
-        new DiagnosticTestArgs('use A\\{ function B as C', 'missing comma or close brace', [ErrorCode.ERR_CommaOrCloseBraceExpected], [23]),
-
-        new DiagnosticTestArgs('use A\\{ function \\B', 'should not parse a fully qualified function name', [ErrorCode.ERR_IdentifierExpected], [16]),
-      ];
-      Test.assertDiagnostics(diagnosticTests);
-
-      let diagnosticTests7_2 = [
-        new DiagnosticTestArgs('use A\\{ function B,', 'missing identifier, import type, or close brace', [ErrorCode.ERR_UseTypeOrCloseBraceExpected], [19]),
-        new DiagnosticTestArgs('use A\\{ function B as C,', 'missing identifier, import type, or close brace (after alias)', [ErrorCode.ERR_UseTypeOrCloseBraceExpected], [24]),
-      ];
-      Test.assertDiagnostics(diagnosticTests7_2, PhpVersion.PHP7_2);
-
-      let featureTrailingCommas = [
-        new DiagnosticTestArgs('use A\\{ function B, };', 'should not parse trailing comma in mixed type import', [ErrorCode.ERR_FeatureTrailingCommasInUseDeclarations], [18]),
-        new DiagnosticTestArgs('use A\\{ function B as C, };', 'should not parse trailing comma in mixed type import (after alias)', [ErrorCode.ERR_FeatureTrailingCommasInUseDeclarations], [23]),
       ];
       Test.assertDiagnostics(featureTrailingCommas, PhpVersion.PHP7_0, PhpVersion.PHP7_1);
     });

--- a/test/src/parser/PhpParserTest_UseDeclaration.ts
+++ b/test/src/parser/PhpParserTest_UseDeclaration.ts
@@ -305,8 +305,10 @@ describe('PhpParser', function() {
       Test.assertDiagnostics(diagnosticTests7_2, PhpVersion.PHP7_2);
 
       let featureTrailingCommas = [
-        new DiagnosticTestArgs('use function A\\{ B, };', 'should not parse trailing comma in function import', [ErrorCode.ERR_FeatureTrailingCommasInUseDeclarations], [18]),
-        new DiagnosticTestArgs('use const A\\{ B, };', 'should not parse trailing comma in constant import', [ErrorCode.ERR_FeatureTrailingCommasInUseDeclarations], [15]),
+        new DiagnosticTestArgs('use function A\\{ B,', 'should not parse trailing comma in function import', [ErrorCode.ERR_FeatureTrailingCommasInUseDeclarations, ErrorCode.ERR_IdentifierOrCloseBraceExpected], [18, 19]),
+        new DiagnosticTestArgs('use function A\\{ B, };', 'should not parse trailing comma in function import (completed)', [ErrorCode.ERR_FeatureTrailingCommasInUseDeclarations], [18]),
+        new DiagnosticTestArgs('use const A\\{ B,', 'should not parse trailing comma in constant import', [ErrorCode.ERR_FeatureTrailingCommasInUseDeclarations, ErrorCode.ERR_IdentifierOrCloseBraceExpected], [15, 16]),
+        new DiagnosticTestArgs('use const A\\{ B, };', 'should not parse trailing comma in constant import (completed)', [ErrorCode.ERR_FeatureTrailingCommasInUseDeclarations], [15]),
       ];
       Test.assertDiagnostics(featureTrailingCommas, PhpVersion.PHP7_0, PhpVersion.PHP7_1);
     });

--- a/tools/parse.php
+++ b/tools/parse.php
@@ -27,4 +27,4 @@ if (file_exists($source)) {
   }
 }
 
-echo ast_dump(ast\parse_code($source, 50)) . PHP_EOL;
+echo ast_dump(ast\parse_code($source, 80)) . PHP_EOL;


### PR DESCRIPTION
This PR tracks the following PHP 8.0 changes:
- [ ] [attributes](https://wiki.php.net/rfc/attributes_v2) (see also: [shorter syntax](https://wiki.php.net/rfc/shorter_attribute_syntax_change))
- [x] [concatenation precedence](https://wiki.php.net/rfc/concatenation_precedence)
- [x] [constructor promotion](https://wiki.php.net/rfc/constructor_promotion)
- [x] [match expressions](https://wiki.php.net/rfc/match_expression_v2)
- [x] [named arguments](https://wiki.php.net/rfc/named_params)
- [x] [nullsafe operator](https://wiki.php.net/rfc/nullsafe_operator)
- [x] [optional catch variables](https://wiki.php.net/rfc/non-capturing_catches)
- [x] [static return type](https://wiki.php.net/rfc/static_return_type)
- [x] [throw expressions](https://wiki.php.net/rfc/throw_expression)
- [x] [trailing comma in closure use list](https://wiki.php.net/rfc/trailing_comma_in_closure_use_list)
- [x] [trailing comma in parameter list](https://wiki.php.net/rfc/trailing_comma_in_parameter_list)
- [x] [union types](https://wiki.php.net/rfc/union_types_v2)
- [ ] [variable syntax tweaks](https://wiki.php.net/rfc/variable_syntax_tweaks)
  - [ ] dereferenceable strings and constants
  - [ ] class name reference expressions

Removed features:
- [x] Brace syntax for element access
- [x] `(real)` cast
- [x] `(unset)` cast

Notes:
- The [ternary associativity](https://wiki.php.net/rfc/ternary_associativity) RFC doesn't actually change the associativity of anything.
- The [namespaced names as single tokens](https://wiki.php.net/rfc/namespaced_names_as_token) RFC needs investigation...